### PR TITLE
Fix slow speed of user agent generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,6 +3328,7 @@ dependencies = [
  "handlebars",
  "log",
  "md5",
+ "once_cell",
  "rand 0.8.5",
  "redis",
  "reqwest 0.11.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ rlua = {version="*"}
 redis = {version="*"}
 md5 = {version="*"}
 rand={version="*"}
+once_cell = {version="*"}

--- a/src/engines/duckduckgo.rs
+++ b/src/engines/duckduckgo.rs
@@ -2,7 +2,7 @@
 //! by querying the upstream duckduckgo search engine with user provided query and with a page
 //! number if provided.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use reqwest::header::{HeaderMap, CONTENT_TYPE, COOKIE, REFERER, USER_AGENT};
 use scraper::{Html, Selector};
@@ -57,6 +57,7 @@ pub async fn results(
     // TODO: Write better error handling code to handle no results case.
     let results: String = reqwest::Client::new()
         .get(url)
+        .timeout(Duration::from_secs(30))
         .headers(header_map) // add spoofed headers to emulate human behaviour
         .send()
         .await?

--- a/src/engines/engine_models.rs
+++ b/src/engines/engine_models.rs
@@ -1,0 +1,8 @@
+#[derive(Debug)]
+pub enum ReqwestError{
+  NotFound,
+  Timeout,
+  Forbidden,
+  AccessDenied,
+  TooManyRequests
+}

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -1,2 +1,3 @@
 pub mod duckduckgo;
+pub mod engine_models;
 pub mod searx;

--- a/src/search_results_handler/user_agent.rs
+++ b/src/search_results_handler/user_agent.rs
@@ -1,15 +1,10 @@
 //! This module provides the functionality to generate random user agent string.
 
-use fake_useragent::{Browsers, UserAgentsBuilder};
+use fake_useragent::{Browsers, UserAgents, UserAgentsBuilder};
 
-/// A function to generate random user agent to improve privacy of the user.
-///
-/// # Returns
-///
-/// A randomly generated user agent string.
-pub fn random_user_agent() -> String {
+static USER_AGENTS: once_cell::sync::Lazy<UserAgents> = once_cell::sync::Lazy::new(|| {
     UserAgentsBuilder::new()
-        .cache(false)
+        .cache(true)
         .dir("/tmp")
         .thread(1)
         .set_browsers(
@@ -21,6 +16,13 @@ pub fn random_user_agent() -> String {
                 .set_mozilla(),
         )
         .build()
-        .random()
-        .to_string()
+});
+
+/// A function to generate random user agent to improve privacy of the user.
+///
+/// # Returns
+///
+/// A randomly generated user agent string.
+pub fn random_user_agent() -> String {
+    USER_AGENTS.random().to_string()
 }


### PR DESCRIPTION
## What does this PR do?

This PR reduces the time it takes to build user agents by enabling caching and using `once_cell` crate.

![image](https://github.com/neon-mmd/websurfx/assets/132049916/84606755-1a3b-48bf-978c-4d8fd3f3a3f4)

## Why is this change important?

This change improves the speed of the server by reducing unnecessary delay to build and fetch random user agents. 

## Author's checklist
- [x] change caching option from `false` to `true`.
- [x] wrap the built user agent value into a `once_cell` static variable

## Related issues

Closes #25 
