### PR TITLE
Support the option to choose whether to add a random delay

### DIFF
--- a/src/config_parser/parser.rs
+++ b/src/config_parser/parser.rs
@@ -49,7 +49,16 @@ impl Config {
                 .load(&fs::read_to_string("./websurfx/config.lua")?)
                 .exec()?;
 
-            let aggregator_config = globals.get::<_, rlua::Table>("aggregator")?;
+            let production_use = globals.get::<_, bool>("production_use")?;
+            let aggregator_config = if production_use {
+                AggreatorConfig {
+                    random_delay: true,
+                }
+            } else {
+                AggreatorConfig {
+                    random_delay: false,
+                }
+            };
 
             Ok(Config {
                 port: globals.get::<_, u16>("port")?,
@@ -59,9 +68,7 @@ impl Config {
                     globals.get::<_, String>("colorscheme")?,
                 ),
                 redis_connection_url: globals.get::<_, String>("redis_connection_url")?,
-                aggregator: AggreatorConfig {
-                    random_delay: aggregator_config.get::<_, bool>("random_delay")?,
-                },
+                aggregator: aggregator_config
             })
         })
     }

--- a/src/config_parser/parser.rs
+++ b/src/config_parser/parser.rs
@@ -20,6 +20,14 @@ pub struct Config {
     pub binding_ip_addr: String,
     pub style: Style,
     pub redis_connection_url: String,
+    pub aggregator: AggreatorConfig,
+}
+
+/// Configuration options for the aggregator.
+#[derive(Clone)]
+pub struct AggreatorConfig {
+    /// Whether to introduce a random delay before sending the request to the search engine.
+    pub random_delay: bool,
 }
 
 impl Config {
@@ -41,6 +49,8 @@ impl Config {
                 .load(&fs::read_to_string("./websurfx/config.lua")?)
                 .exec()?;
 
+            let aggregator_config = globals.get::<_, rlua::Table>("aggregator")?;
+
             Ok(Config {
                 port: globals.get::<_, u16>("port")?,
                 binding_ip_addr: globals.get::<_, String>("binding_ip_addr")?,
@@ -49,6 +59,9 @@ impl Config {
                     globals.get::<_, String>("colorscheme")?,
                 ),
                 redis_connection_url: globals.get::<_, String>("redis_connection_url")?,
+                aggregator: AggreatorConfig {
+                    random_delay: aggregator_config.get::<_, bool>("random_delay")?,
+                },
             })
         })
     }

--- a/src/config_parser/parser.rs
+++ b/src/config_parser/parser.rs
@@ -51,9 +51,7 @@ impl Config {
 
             let production_use = globals.get::<_, bool>("production_use")?;
             let aggregator_config = if production_use {
-                AggreatorConfig {
-                    random_delay: true,
-                }
+                AggreatorConfig { random_delay: true }
             } else {
                 AggreatorConfig {
                     random_delay: false,
@@ -68,7 +66,7 @@ impl Config {
                     globals.get::<_, String>("colorscheme")?,
                 ),
                 redis_connection_url: globals.get::<_, String>("redis_connection_url")?,
-                aggregator: aggregator_config
+                aggregator: aggregator_config,
             })
         })
     }

--- a/src/search_results_handler/aggregator.rs
+++ b/src/search_results_handler/aggregator.rs
@@ -29,6 +29,7 @@ use crate::engines::{duckduckgo, searx};
 ///
 /// * `query` - Accepts a string to query with the above upstream search engines.
 /// * `page` - Accepts an u32 page number.
+/// * `random_delay` - Accepts a boolean value to add a random delay before making the request.
 ///
 /// # Error
 ///
@@ -38,14 +39,17 @@ use crate::engines::{duckduckgo, searx};
 pub async fn aggregate(
     query: &str,
     page: u32,
+    random_delay: bool,
 ) -> Result<SearchResults, Box<dyn std::error::Error>> {
     let user_agent: String = random_user_agent();
     let mut result_map: HashMap<String, RawSearchResult> = HashMap::new();
 
     // Add a random delay before making the request.
-    let mut rng = rand::thread_rng();
-    let delay_secs = rng.gen_range(1..10);
-    std::thread::sleep(Duration::from_secs(delay_secs));
+    if random_delay {
+        let mut rng = rand::thread_rng();
+        let delay_secs = rng.gen_range(1..10);
+        std::thread::sleep(Duration::from_secs(delay_secs));
+    }
 
     // fetch results from upstream search engines simultaneously/concurrently.
     let (ddg_map_results, searx_map_results) = join!(

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -127,7 +127,7 @@ pub async fn search(
                     }
                     Err(_) => {
                         let mut results_json: crate::search_results_handler::aggregation_models::SearchResults =
-                            aggregate(query, page).await?;
+                            aggregate(query, page, config.aggregator.random_delay).await?;
                         results_json.add_style(config.style.clone());
                         redis_cache
                             .cache_results(serde_json::to_string(&results_json)?, &page_url)?;

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -19,3 +19,8 @@ theme = "simple" -- the theme name which should be used for the website
 
 -- Caching
 redis_connection_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
+
+-- Aggregator
+aggregator = {
+  random_delay = false, -- whether to add random delay before sending the request to the search engine
+}

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -20,6 +20,6 @@ theme = "simple" -- the theme name which should be used for the website
 -- Caching
 redis_connection_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
 
-production_use = false -- whether to use production mode or not
+production_use = false -- whether to use production mode or not (in other words this option should be used if it is to be used to host it on the server to provide a service to a large number of users)
 -- if production_use is set to true
-  -- there will be a random delay before sending the request to the search engines, this is to prevent the search engines from blocking the ip address
+  -- There will be a random delay before sending the request to the search engines, this is to prevent DDoSing the upstream search engines from a large number of simultaneous requests.

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -20,7 +20,6 @@ theme = "simple" -- the theme name which should be used for the website
 -- Caching
 redis_connection_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
 
--- Aggregator
-aggregator = {
-  random_delay = false, -- whether to add random delay before sending the request to the search engine
-}
+production_use = false -- whether to use production mode or not
+-- if production_use is set to true
+  -- there will be a random delay before sending the request to the search engines, this is to prevent the search engines from blocking the ip address


### PR DESCRIPTION
## What does this PR do?
This pull request adds a new feature that allows users to choose whether or not to use websurfx in a production environment. With this update, you can set the `production_use` flag to `true` to introduce a random delay before sending requests to the search engine. Conversely, if you prefer to disable this functionality, you can simply change the option to `false`, like so:
```lua
production_use = false
```

## Why is this change important?
This new feature provides users with greater flexibility and control over how they use the tool.

