### PR TITLE
 Fix slow speed of user agent generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,6 +3328,7 @@ dependencies = [
  "handlebars",
  "log",
  "md5",
+ "once_cell",
  "rand 0.8.5",
  "redis",
  "reqwest 0.11.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ rlua = {version="*"}
 redis = {version="*"}
 md5 = {version="*"}
 rand={version="*"}
+once_cell = {version="*"}

--- a/src/search_results_handler/user_agent.rs
+++ b/src/search_results_handler/user_agent.rs
@@ -1,13 +1,8 @@
 //! This module provides the functionality to generate random user agent string.
 
-use fake_useragent::{Browsers, UserAgentsBuilder};
+use fake_useragent::{Browsers, UserAgents, UserAgentsBuilder};
 
-/// A function to generate random user agent to improve privacy of the user.
-///
-/// # Returns
-///
-/// A randomly generated user agent string.
-pub fn random_user_agent() -> String {
+static USER_AGENTS: once_cell::sync::Lazy<UserAgents> = once_cell::sync::Lazy::new(|| {
     UserAgentsBuilder::new()
         .cache(false)
         .dir("/tmp")
@@ -21,6 +16,13 @@ pub fn random_user_agent() -> String {
                 .set_mozilla(),
         )
         .build()
-        .random()
-        .to_string()
+});
+
+/// A function to generate random user agent to improve privacy of the user.
+///
+/// # Returns
+///
+/// A randomly generated user agent string.
+pub fn random_user_agent() -> String {
+    USER_AGENTS.random().to_string()
 }


### PR DESCRIPTION
## What does this PR do?

This PR reduces the time it takes to build user agents by enabling caching and using `once_cell` crate.

![image](https://github.com/neon-mmd/websurfx/assets/132049916/84606755-1a3b-48bf-978c-4d8fd3f3a3f4)

## Why is this change important?

This change improves the speed of the server by reducing unnecessary delay to build and fetch random user agents. 

## Author's checklist
- [x] wrap the built user agent value into a `once_cell` static variable

## Related issues

Closes #25 

Re-opening PR #34 