### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,15 @@ FROM rust:latest AS chef
 # it will be cached from the second build onwards
 RUN cargo install cargo-chef
 
-WORKDIR app
-
+WORKDIR /app
 FROM chef AS planner
 COPY . . 
 RUN cargo chef prepare --recipe-path recipe.json
 
+# Builder
 FROM chef AS builder
+
+WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json
@@ -20,6 +22,7 @@ RUN cargo install --path .
 
 # We do not need the Rust toolchain to run the binary!
 FROM gcr.io/distroless/cc-debian11
+WORKDIR /app
 COPY --from=builder ./public/ ./public/
 COPY --from=builder ./websurfx/ ./websurfx/
 COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/


### PR DESCRIPTION
## What does this PR do?

Update's the Dockerfile to successfully build on all platforms. This includes adjustments to the `WORKDIR` command as using relative paths breaks across different containers.

## Why is this change important?

Docker now builds correctly according to the wiki instructions.

## How to test this PR locally?

Actually ran `docker-compose up -d --build` as well as `docker built .` from the root of the directory.

Following this, (and tweaks to the configs to work within the docker compose environment ) I was able to successfully perform searches.
