### PR TITLE
Reorder config file options and make headings stand out

### DIFF
--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -1,8 +1,11 @@
--- Server
+-- ### Server ###
 port = "8080" -- port on which server should be launched
 binding_ip_addr = "127.0.0.1" --ip address on the which server should be launched.
+production_use = false -- whether to use production mode or not (in other words this option should be used if it is to be used to host it on the server to provide a service to a large number of users)
+-- if production_use is set to true
+-- There will be a random delay before sending the request to the search engines, this is to prevent DDoSing the upstream search engines from a large number of simultaneous requests.
 
--- Website
+-- ### Website ###
 -- The different colorschemes provided are:
 -- {{
 -- catppuccin-mocha
@@ -17,9 +20,5 @@ binding_ip_addr = "127.0.0.1" --ip address on the which server should be launche
 colorscheme = "catppuccin-mocha" -- the colorscheme name which should be used for the website theme
 theme = "simple" -- the theme name which should be used for the website
 
--- Caching
+-- ### Caching ###
 redis_connection_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
-
-production_use = false -- whether to use production mode or not (in other words this option should be used if it is to be used to host it on the server to provide a service to a large number of users)
--- if production_use is set to true
-  -- There will be a random delay before sending the request to the search engines, this is to prevent DDoSing the upstream search engines from a large number of simultaneous requests.


### PR DESCRIPTION
## What does this PR do?

This PR reorders config file option `production_use` under the heading of  `Server` and also made the heading stand out.

## Why is this change important?

This change makes the config file more organized and less ambiguous for the user and makes the configuration options more clear and also made the header stand out so that they are more noticeable and do not look similar to regular comments.

## Related issues

Closes #65  
