### PR TITLE
Github CI to automate the generation of contributors list

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,16 @@
+name: Contributors
+on:
+  schedule:
+    - cron: '0 1 * * *' # At 01:00 on every day.
+  push:
+    branches:
+      - rolling
+jobs:
+  contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/contributors-list@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          round: true
+          svgPath: ../../images/contributors_list.svg


### PR DESCRIPTION
## What does this PR do?

This PR adds a GitHub CI to automate the generation of the contributors' list.

## Why is this change important?

This change is essential as this way is a better solution to provide a contributors' list as previously seemed to lag behind in showing the actual numbers of contributors (as shown in the images below)  in the contributors under the `Credits` section of the `Readme`. 

![image](https://github.com/neon-mmd/websurfx/assets/132049916/80af59fe-6e88-47ca-ac71-b2315ce4f6e9)

![image](https://github.com/neon-mmd/websurfx/assets/132049916/8746cddd-b3f4-4536-b169-d84bc667f46a)

## Related issues

Closes #78 
