### PR TITLE
fix the contributor list action

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           round: true
-          svgPath: ../../images/contributors_list.svg
+          svgPath: images/contributors_list.svg


### PR DESCRIPTION
## What does this PR do?
The ci job created by #79 has failed with an error that says `path contains a malformed path component`, see https://github.com/neon-mmd/websurfx/actions/runs/5118972646/jobs/9203639769 for more details.

Based on the example provided in https://github.com/wow-actions/contributors-list/blob/master/.github/workflows/contributors.yml, it appears that the path should be a relative path with respect to the repository root.

