### PR TITLE
Fix: Font case in engines_tab.html

### DIFF
--- a/public/templates/engines_tab.html
+++ b/public/templates/engines_tab.html
@@ -18,7 +18,7 @@
                 <input type="checkbox" class="engine" />
                 <span class="slider round"></span>
             </label>
-            Duckduckgo
+            DuckDuckGo
         </div>
         <div class="toggle_btn">
             <label class="switch">


### PR DESCRIPTION
## What does this PR do?

Fixed word `duckduckgo` spelling in the file engines_tab.html.

## Related Issues 

Closes #112 
