### PR TITLE
Rename getter functions to follow Rust naming convention

### DIFF
--- a/src/cache/cacher.rs
+++ b/src/cache/cacher.rs
@@ -41,7 +41,7 @@ impl RedisCache {
     /// # Arguments
     ///
     /// * `url` - It takes an url as a string.
-    pub fn get_cached_json(&mut self, url: &str) -> Result<String, Box<dyn std::error::Error>> {
+    pub fn cached_json(&mut self, url: &str) -> Result<String, Box<dyn std::error::Error>> {
         let hashed_url_string = Self::hash_url(url);
         Ok(self.connection.get(hashed_url_string)?)
     }

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -50,7 +50,7 @@ impl Config {
             let globals = context.globals();
 
             context
-                .load(&fs::read_to_string(Config::get_config_path()?)?)
+                .load(&fs::read_to_string(Config::config_path()?)?)
                 .exec()?;
 
             Ok(Config {
@@ -81,7 +81,7 @@ impl Config {
     ///    one (3).
     /// 3. `websurfx/` (under project folder ( or codebase in other words)) if it is not present
     ///    here then it returns an error as mentioned above.
-    fn get_config_path() -> Result<String, Box<dyn std::error::Error>> {
+    fn config_path() -> Result<String, Box<dyn std::error::Error>> {
         // check user config
 
         let path = format!(

--- a/src/handler/public_paths.rs
+++ b/src/handler/public_paths.rs
@@ -17,7 +17,7 @@ static PUBLIC_DIRECTORY_NAME: &str = "public";
 /// 1. `/opt/websurfx` if it not present here then it fallbacks to the next one (2)
 /// 2. Under project folder ( or codebase in other words) if it is not present
 ///    here then it returns an error as mentioned above.
-pub fn get_public_path() -> Result<String, Error> {
+pub fn public_path() -> Result<String, Error> {
     if Path::new(format!("/opt/websurfx/{}/", PUBLIC_DIRECTORY_NAME).as_str()).exists() {
         return Ok(format!("/opt/websurfx/{}", PUBLIC_DIRECTORY_NAME));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use actix_files as fs;
 use actix_web::{dev::Server, middleware::Logger, web, App, HttpServer};
 use config::parser::Config;
 use handlebars::Handlebars;
-use handler::public_paths::get_public_path;
+use handler::public_paths::public_path;
 
 /// Runs the web server on the provided TCP listener and returns a `Server` instance.
 ///
@@ -41,7 +41,7 @@ use handler::public_paths::get_public_path;
 pub fn run(listener: TcpListener, config: Config) -> std::io::Result<Server> {
     let mut handlebars: Handlebars = Handlebars::new();
 
-    let public_folder_path: String = get_public_path()?;
+    let public_folder_path: String = public_path()?;
 
     handlebars
         .register_templates_directory(".html", format!("{}/templates", public_folder_path))


### PR DESCRIPTION
## What does this PR do?
This PR changes the names of the getter functions to follow the rust naming convention, as mentioned in [this issue](https://github.com/neon-mmd/websurfx/issues/135).
<!-- MANDATORY -->
In the changes made, the function `get_cached_json()` is renamed to `cached_json()`, `get_config_path()` is renamed to `config_path()`, `get_results()` is renamed to `results()`, and `get_public_path()` is renamed to `public_path()`. All uses of the functions have been changed to use the new names as well. 
<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
This change is meant to resolve the above issue, [Rename getter functions' name #135.
](https://github.com/neon-mmd/websurfx/issues/135)
It is not a significant change, but using better naming conventions is good for clarity in the code. 
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?
Run the project normally, use the functions to see if they still work as intended. 
<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewers -->
I am somewhat new to this, so I apologize for any mistakes I might have made. Cargo building didn't change any files, but I assume that is because renaming doesn't change the complied program. 
## Related issues
[Rename getter functions' name #135
](https://github.com/neon-mmd/websurfx/issues/135)
<!--
Closes #135
-->
