### PR TITLE
Update the colorschemes in `public/static/colorschemes`

### DIFF
--- a/public/static/colorschemes/gruvbox-dark.css
+++ b/public/static/colorschemes/gruvbox-dark.css
@@ -1,7 +1,7 @@
 :root {
-  --background-color: #282828;
+  --background-color: #1d2021;
   --foreground-color: #ebdbb2;
-  --color-one: #cc241d;
+  --color-one: #282828;
   --color-two: #98971a;
   --color-three: #d79921;
   --color-four: #458588;

--- a/public/static/colorschemes/monokai.css
+++ b/public/static/colorschemes/monokai.css
@@ -1,8 +1,8 @@
 :root {
-  --background-color: #403e41;
-  --foreground-color: #fcfcfa;
-  --color-one: #ff6188;
-  --color-two: #a9dc76;
+  --background-color: #49483Eff;
+  --foreground-color: #FFB269;
+  --color-one: #272822ff;
+  --color-two: #61AFEF;
   --color-three: #ffd866;
   --color-four: #fc9867;
   --color-five: #ab9df2;

--- a/public/static/colorschemes/nord.css
+++ b/public/static/colorschemes/nord.css
@@ -1,11 +1,11 @@
 :root {
-  --background-color: #2e3440;
-  --foreground-color: #d8dee9;
-  --color-one: #3b4252;
-  --color-two: #bf616a;
-  --color-three: #a3be8c;
-  --color-four: #ebcb8b;
+  --background-color: #122736ff;
+  --foreground-color: #a2e2a9;
+  --color-one: #121B2Cff;
+  --color-two: #f08282;
+  --color-three: #ABC5AAff;
+  --color-four: #e6d2d2;
   --color-five: #81a1c1;
-  --color-six: #b48ead;
-  --color-seven: #ffffff;
+  --color-six: #e2ecd6;
+  --color-seven: #fff;
 }

--- a/public/static/colorschemes/oceanic-next.css
+++ b/public/static/colorschemes/oceanic-next.css
@@ -2,10 +2,10 @@
   --background-color: #1b2b34;
   --foreground-color: #d8dee9;
   --color-one: #343d46;
-  --color-two: #ec5f67;
-  --color-three: #99c794;
-  --color-four: #fac863;
-  --color-five: #6699cc;
+  --color-two: #5FB3B3ff;
+  --color-three: #69Cf;
+  --color-four: #99c794;
+  --color-five: #69c;
   --color-six: #c594c5;
-  --color-seven: #ffffff;
+  --color-seven: #D8DEE9ff;
 }

--- a/public/static/colorschemes/solarized-dark.css
+++ b/public/static/colorschemes/solarized-dark.css
@@ -1,6 +1,6 @@
 :root {
   --background-color: #002b36;
-  --foreground-color: #667A7Fff;
+  --foreground-color: #c9e0e6;
   --color-one: #073642;
   --color-two: #2AA198ff;
   --color-three: #2AA198ff;

--- a/public/static/colorschemes/solarized-dark.css
+++ b/public/static/colorschemes/solarized-dark.css
@@ -1,11 +1,11 @@
 :root {
   --background-color: #002b36;
-  --foreground-color: #839496;
+  --foreground-color: #667A7Fff;
   --color-one: #073642;
-  --color-two: #dc322f;
-  --color-three: #859900;
-  --color-four: #b58900;
+  --color-two: #2AA198ff;
+  --color-three: #2AA198ff;
+  --color-four: #EEE8D5ff;
   --color-five: #268bd2;
   --color-six: #d33682;
-  --color-seven: #ffffff;
+  --color-seven: #fff;
 }

--- a/public/static/colorschemes/solarized-light.css
+++ b/public/static/colorschemes/solarized-light.css
@@ -1,11 +1,11 @@
 :root {
-  --background-color: #fdf6e3;
-  --foreground-color: #657b83;
-  --color-one: #073642;
-  --color-two: #dc322f;
-  --color-three: #859900;
+  --background-color: #EEE8D5ff;
+  --foreground-color: #B58900ff;
+  --color-one: #fdf6e3;
+  --color-two: #DC322Fff;
+  --color-three: #586E75ff;
   --color-four: #b58900;
   --color-five: #268bd2;
   --color-six: #d33682;
-  --color-seven: #ffffff;
+  --color-seven: #fff;
 }

--- a/public/static/colorschemes/solarized-light.css
+++ b/public/static/colorschemes/solarized-light.css
@@ -1,6 +1,6 @@
 :root {
   --background-color: #EEE8D5ff;
-  --foreground-color: #B58900ff;
+  --foreground-color: #b1ab97;
   --color-one: #fdf6e3;
   --color-two: #DC322Fff;
   --color-three: #586E75ff;

--- a/public/static/colorschemes/tomorrow-night.css
+++ b/public/static/colorschemes/tomorrow-night.css
@@ -1,11 +1,11 @@
 :root {
-  --background-color: #1d1f21;
-  --foreground-color: #c5c8c6;
-  --color-one: #cc6666;
-  --color-two: #b5bd68;
+  --background-color: #35383Cff;
+  --foreground-color: #D7DAD8ff;
+  --color-one: #1d1f21;
+  --color-two: #D77C79ff;
   --color-three: #f0c674;
-  --color-four: #81a2be;
-  --color-five: #b294bb;
-  --color-six: #8abeb7;
-  --color-seven: #ffffff;
+  --color-four: #92B2CAff;
+  --color-five: #C0A7C7ff;
+  --color-six: #9AC9C4ff;
+  --color-seven: #fff;
 }


### PR DESCRIPTION
## What does this PR do?
This PR updates the colors of the colorschemes located in the `public/static/colorschemes` folder as mentioned in [this issue](https://github.com/neon-mmd/websurfx/issues/124#issue-1780994932). The colorschemes `catppuccin-mocha`, `dracula`, `tokyo-night`, `one-dark` and `dark-chocolate` have been left the same. With the exception of solarized light/dark in which I have updated the foreground color to make the search text more readable, the updated themes can be found in the discord, but I will add them below as well.

<details>
<summary>Updated themes</summary>
<br>
Tomorrow Night:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/169ad824-4b2c-458f-8aa8-585e2008ec19>
Gruvbox Dark:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/5f009a97-b658-4fb9-9040-fbbb7d7de43e)>
Monokai:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/a936ffd3-b1da-497d-bf90-d2c5ae6cbf7b)>
Nord:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/0a956b6c-7e36-4a0a-85f9-9db5e46316c0)>
Oceanic Next:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/0562a4a3-21f3-46ad-b3a8-323cca7df6aa)>
Solarized Dark:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/4cd33386-a87a-4d36-9e6a-7f3f679645f3)>
Solarized Light:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/7d48f243-6da4-45aa-8fe3-ae0490fb600f)>
</details>

<details>
<summary>Old themes</summary>
<br>
Tomorrow Night:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/e8d26fca-ed50-4678-bf5b-5f2590d694fd)>
Gruvbox Dark:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/6d78ca10-ec47-4bf9-a566-ed83689b651b)>
Monokai:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/9efa2626-1d7e-4433-8a35-4f7764461775)>
Nord:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/2c136c9e-ca55-40f9-878c-65113eb70d0f)>
Oceanic Next:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/6bc06561-6ea1-4e48-bdd5-b38060bf87fb)>
Solarized Dark:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/64dd0c9e-0d8e-41da-bae9-a3bb387a0cc4)>
Solarized Light:
<img src=https://github.com/neon-mmd/websurfx/assets/107130695/aeaecc32-f6f7-4ce6-a97e-90dcab047047)>
</details>
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
Many of the old themes seemed to have some values switched around, and what was likely intended to be an accent color became the background. This is especially clear in the old solarized light theme, which is the same as solarized dark, but has very bright edges. Hopefully updating the themes will make the user experience a bit better. 
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?
Run websurfx normally, switch through the themes in settings if you want to look at them individually. I might have missed some things, as there are some values that seem to never actually show up anywhere in the interface which I just left alone. 
<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

Not much to note, but as stated previously, I couldn't find any uses for some of the values in the interface (like `--color-five` or `--color-six`), so I just left those alone, but they might require some revision. 
<!-- additional notes for reviewers -->

## Related issues
[Make improvements to colorschemes to make it look right #124](https://github.com/neon-mmd/websurfx/issues/124#issue-1780994932)
<!--
Closes #124 
-->
