### PR TITLE
Colorschemes updated in config.lua

### DIFF
--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -13,12 +13,16 @@ production_use = false -- whether to use production mode or not (in other words 
 -- The different colorschemes provided are:
 -- {{
 -- catppuccin-mocha
+-- dark-chocolate
 -- dracula
+-- gruvbox-dark
 -- monokai
 -- nord
 -- oceanic-next
+-- one-dark
 -- solarized-dark
 -- solarized-light
+-- tokyo-night
 -- tomorrow-night
 -- }}
 colorscheme = "catppuccin-mocha" -- the colorscheme name which should be used for the website theme


### PR DESCRIPTION
## What does this PR do?

Documentation update

## Why is this change important?

The documentation in the config file located in websurfx/config.lua was out of sync with the introduction of new colorschemes in the [PR #77](https://github.com/neon-mmd/websurfx/issues/77).

## Related issues

Closes #156 