### PR TITLE
✨ Config option to allow users to customize the number of threads used by the app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,11 +460,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -1912,9 +1913,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1922,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f94bca7e7a599d89dea5dfa309e217e7906c3c007fb9c3299c40b10d6a315d3"
+checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1932,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
+checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1945,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674c66ebb4b4d9036012091b537aae5878970d6999f81a265034d85b136b341"
+checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
 dependencies = [
  "once_cell",
  "pest",
@@ -2523,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -3518,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "websurfx"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "0.15.3"
+version = "0.16.0"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/src/bin/websurfx.rs
+++ b/src/bin/websurfx.rs
@@ -4,7 +4,6 @@
 //! stdout and handles the command line arguments provided and launches the `websurfx` server.
 
 use std::net::TcpListener;
-
 use websurfx::{config::parser::Config, run};
 
 /// The function that launches the main server and registers all the routes of the website.
@@ -18,13 +17,16 @@ async fn main() -> std::io::Result<()> {
     // Initialize the parsed config file.
     let config = Config::parse().unwrap();
 
-    // Initializing logging middleware with level set to default or info.
-    if config.logging || config.debug {
-        use env_logger::Env;
-        env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
-    }
-
-    log::info!("started server on port {}", config.port);
+    log::info!(
+        "started server on port {} and IP {}",
+        config.port,
+        config.binding_ip
+    );
+    log::info!(
+        "Open http://{}:{}/ in your browser",
+        config.port,
+        config.binding_ip
+    );
 
     let listener = TcpListener::bind((config.binding_ip.clone(), config.port))?;
 

--- a/src/bin/websurfx.rs
+++ b/src/bin/websurfx.rs
@@ -15,7 +15,7 @@ use websurfx::{config::parser::Config, run};
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     // Initialize the parsed config file.
-    let config = Config::parse().unwrap();
+    let config = Config::parse(true).unwrap();
 
     log::info!(
         "started server on port {} and IP {}",

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -91,7 +91,7 @@ impl Config {
                         .lock()
                         .write_all(&format!("Config Error: The value of `threads` option should be a non zero positive integer\nFalling back to using {} threads\n", total_num_of_threads).into_bytes())?;
                 };
-                total_num_of_threads as u8 
+                total_num_of_threads as u8
             } else {
                 parsed_threads
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub fn run(listener: TcpListener, config: Config) -> std::io::Result<Server> {
 
     let handlebars_ref: web::Data<Handlebars> = web::Data::new(handlebars);
 
+    let cloned_config_threads_opt: u8 = config.threads;
+
     let server = HttpServer::new(move || {
         App::new()
             .app_data(handlebars_ref.clone())
@@ -70,6 +72,7 @@ pub fn run(listener: TcpListener, config: Config) -> std::io::Result<Server> {
             .service(routes::settings) // settings page
             .default_service(web::route().to(routes::not_found)) // error page
     })
+    .workers(cloned_config_threads_opt as usize)
     // Start server on 127.0.0.1 with the user provided port number. for example 127.0.0.1:8080.
     .listen(listener)?
     .run();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use handler::public_paths::public_path;
 /// use std::net::TcpListener;
 /// use websurfx::{config::parser::Config, run};
 ///
-/// let config = Config::parse().unwrap();
+/// let config = Config::parse(true).unwrap();
 /// let listener = TcpListener::bind("127.0.0.1:8080").expect("Failed to bind address");
 /// let server = run(listener,config).expect("Failed to start server");
 /// ```

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -8,7 +8,7 @@ fn spawn_app() -> String {
     // Binding to port 0 will trigger the OS to assign a port for us.
     let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port");
     let port = listener.local_addr().unwrap().port();
-    let config = Config::parse().unwrap();
+    let config = Config::parse(true).unwrap();
     let server = run(listener, config).expect("Failed to bind address");
 
     tokio::spawn(server);
@@ -36,7 +36,7 @@ async fn test_index() {
     assert_eq!(res.status(), 200);
 
     let handlebars = handlebars();
-    let config = Config::parse().unwrap();
+    let config = Config::parse(false).unwrap();
     let template = handlebars.render("index", &config.style).unwrap();
     assert_eq!(res.text().await.unwrap(), template);
 }

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -1,6 +1,7 @@
 -- ### General ###
 logging = true -- an option to enable or disable logs.
 debug = false -- an option to enable or disable debug mode.
+threads = 10 -- the amount of threads that the app will use to run (the value should be greater than 0).
 
 -- ### Server ###
 port = "8080" -- port on which server should be launched


### PR DESCRIPTION
## What does this PR do?

This PR provides a new config option `threads` and improves the logs generated by the app.

## Why is this change important?

This PR is essential as it allows the user to control the amount of threads that the app should use according to their system requirement. Also, this PR improves the logging, which is essential as this allows errors to also be logged from the config parser module `parser.rs` which were previously not being logged.

## How to test this PR locally?

It can be tested by installing and running `Websurfx` as mentioned in the `docs` and on the `readme` and by launching the browser and thoroughly testing. Checking the logs that get displayed on standard output when either `debug` or `logging` is set to true or false.

## Author's checklist

- [x] adds a new config option `threads`.
- [x] improves the logging functionality in the app.
- [x] bumps the app version to `v0.16.0`. 

## Related issues

Closes #169
