### PR TITLE
📝 Fix link to Documentation in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <b align="center"><a href="README.md">Readme</a></b> |
   <b><a href="https://discord.gg/SWnda7Mw5u">Discord</a></b> |
   <b><a href="https://github.com/neon-mmd/websurfx">GitHub</a></b> |
-  <b><a href="./docs/README.md">Documentation</a></b>
+  <b><a href="../../tree/HEAD/docs/">Documentation</a></b>
   <br /><br />
   <a href="#">
     <img


### PR DESCRIPTION
## What does this PR do?
No code changes, I just noticed that because the default branch is currently `rolling`, the link to the documentation was referencing `https://github.com/neon-mmd/docs/` which returns a 404. This update should fix that :)

(Have used `HEAD` instead of `rolling`, so that if you rename or change you default branch in the future, the link won't break)

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Because it let's users read the docs without getting a 404 ;)

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

If you click the three dots (top left), then view file, then click the link to Documentation, it _should_ now resolve to the docs directory.

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

N/A 

<!--
Closes #234
-->

P.S - your project looks awesome! Great work :)
