### PR TITLE
🛠️ Bump the version of Debian distroless container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN cargo install --path .
 
 # We do not need the Rust toolchain to run the binary!
-FROM gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian12
 COPY --from=builder /app/public/ /opt/websurfx/public/
 COPY --from=builder /app/websurfx/config.lua /etc/xdg/websurfx/config.lua
 COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/


### PR DESCRIPTION
## What does this PR do?

This PR bumps the Debian container version to 12.

## Why is this change important?

By working on this issue, it will automatically fix the issue https://github.com/neon-mmd/websurfx/issues/197

## Related Issues

Closes #209 