### PR TITLE
🛠️ Rename the `redis_connection_url` to `redis_url` in the sample config file

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,7 +109,7 @@ colorscheme = "catppuccin-mocha" -- the colorscheme name which should be used fo
 theme = "simple" -- the theme name which should be used for the website
 
 -- ### Caching ###
-redis_connection_url = "redis://redis:6379" -- redis connection url address on which the client should connect on.
+redis_url = "redis://redis:6379" -- redis connection url address on which the client should connect on.
 
 -- ### Search Engines ###
 upstream_search_engines = { DuckDuckGo = true, Searx = false } -- select the upstream search engines from which the results should be fetched.


### PR DESCRIPTION
## What does this PR do?

Fix the sample config file provided in the installation docs by renaming the redis_connection_url to redis_url.

renamed the redis_connection_url to redis_url.

## Why is this change important?

this fixes the issue.

<!-- explain the motivation behind your PR -->

## Author's checklist

- [x] Rename `redis_connection_url` to `redis_url` in the sample config.

## Related issues
Closes #218 

