### PR TITLE
📝 A link to the `Websurfx` instances documentation page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "websurfx"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 <p align="center">
   <b align="center"><a href="README.md">Readme</a></b> |
   <b><a href="https://discord.gg/SWnda7Mw5u">Discord</a></b> |
+  <b><a href="../../tree/HEAD/docs/instances.md">Instances</a></b> |
   <b><a href="https://discord.gg/VKCAememnr">User Showcase</a></b> |
   <b><a href="https://github.com/neon-mmd/websurfx">GitHub</a></b> |
   <b><a href="../../tree/HEAD/docs/">Documentation</a></b>


### PR DESCRIPTION
## What does this PR do?

Provide a link to the Websurfx instances documentation page under the Websurfx logo in the Readme file to allow users to visit the instances page quickly and use the instances provided on that page. 

## Related Issues 

Closes #255 