### PR TITLE
✨  Initial NixOS support via `flake.nix`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-/target
-package.json
-package-lock.json
-dump.rdb
 .vscode
-megalinter-reports/
+/target
 dhat-heap.json
+dump.rdb
+megalinter-reports/
+package-lock.json
+package.json
+result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "0.23.5"
+version = "0.23.6"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -162,4 +162,41 @@ cd websurfx
 git checkout stable
 ```
 
+## NixOS
+
+A flake.nix has been provided to allow installing `Websurfx` easily. It utilizes [nearsk](https://github.com/nix-community/naersk) to automatically generate a derivation based on `Cargo.toml` and `Cargo.lock`.
+
+The flake has several outputs, which may be consumed:
+
+~~~bash
+nix build .#websurfx
+nix run .#websurfx
+~~~
+
+You may include it in your own flake by adding this repo to its inputs and adding it to `environment.systemPackages`
+
+~~~nix
+{
+  description = "My configuration";
+
+  inputs = {
+    websurfx.url = "github:neon-mmd/websurfx";
+  };
+
+  outputs = { nixpkgs, ... }@inputs: {
+    nixosConfigurations = {
+      hostname = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [{
+			environment.systemPackages = [
+				inputs.websurfx.websurfx
+			];
+		}];
+      };
+    };
+  };
+}
+
+~~~
+
 [⬅️ Go back to Home](./README.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,6 +19,40 @@ Once you have started the server, open your preferred web browser and navigate t
 
 If you want to change the port or the ip or any other configuration setting checkout the [configuration docs](./configuration.md).
 
+## NixOS
+
+A `flake.nix` has been provided to allow installing `websurfx` easily. It utilizes [nearsk](https://github.com/nix-community/naersk) to automatically generate a derivation based on `Cargo.toml` and `Cargo.lock`.
+
+The flake has several outputs, which may be consumed:
+
+```bash
+nix build .#websurfx
+nix run .#websurfx
+```
+
+You may include it in your own flake by adding this repo to its inputs and adding it to `environment.systemPackages` as follows:
+
+```nix
+{
+  description = "My awesome configuration";
+
+  inputs = {
+    websurfx.url = "github:neon-mmd/websurfx";
+  };
+
+  outputs = { nixpkgs, ... }@inputs: {
+    nixosConfigurations = {
+      hostname = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [{
+          environment.systemPackages = [inputs.websurfx.packages.x86_64-linux.websurfx];
+        }];
+      };
+    };
+  };
+}
+```
+
 ## Other Distros
 
 The package is currently not available on other Linux distros. With contribution and support it can be made available on other distros as well 🙂.
@@ -161,42 +195,5 @@ git clone https://github.com/neon-mmd/websurfx.git
 cd websurfx
 git checkout stable
 ```
-
-## NixOS
-
-A flake.nix has been provided to allow installing `Websurfx` easily. It utilizes [nearsk](https://github.com/nix-community/naersk) to automatically generate a derivation based on `Cargo.toml` and `Cargo.lock`.
-
-The flake has several outputs, which may be consumed:
-
-~~~bash
-nix build .#websurfx
-nix run .#websurfx
-~~~
-
-You may include it in your own flake by adding this repo to its inputs and adding it to `environment.systemPackages`
-
-~~~nix
-{
-  description = "My configuration";
-
-  inputs = {
-    websurfx.url = "github:neon-mmd/websurfx";
-  };
-
-  outputs = { nixpkgs, ... }@inputs: {
-    nixosConfigurations = {
-      hostname = nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
-        modules = [{
-			environment.systemPackages = [
-				inputs.websurfx.websurfx
-			];
-		}];
-      };
-    };
-  };
-}
-
-~~~
 
 [⬅️ Go back to Home](./README.md)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1694081375,
+        "narHash": "sha256-vzJXOUnmkMCm3xw8yfPP5m8kypQ3BhAIRe4RRCWpzy8=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "3f976d822b7b37fc6fb8e6f157c2dd05e7e94e89",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "path": "/nix/store/p7iz0r8gs6ppkhj83zjmwyd21k8b7v3y-source",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       pkgs = import nixpkgs {inherit system;};
       naersk-lib = pkgs.callPackage naersk {};
     in rec {
-      # Build via nix build .#defaultPackage.x86_64-linux
+      # Build via "nix build .#default"
       packages.default = naersk-lib.buildPackage {
         # The build dependencies
         buildInputs = with pkgs; [pkg-config openssl];
@@ -37,7 +37,7 @@
             nodePackages_latest.eslint
             nodePackages_latest.markdownlint-cli2
             nodePackages_latest.stylelint
-            nodePackages_latest.stylelint
+            redis
             rustPackages.clippy
             rustc
             yamllint
@@ -45,7 +45,8 @@
           RUST_SRC_PATH = rustPlatform.rustLibSrc;
         };
 
-      # Build via "nix build .#websurfx.x86_64-linux"
+      # Build via "nix build .#websurfx", which is basically just
+      # calls the build function
       packages.websurfx = packages.default;
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  # Websurfx NixOS flake
+  inputs = {
+    naersk.url = "github:nix-community/naersk/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    naersk,
+    nixpkgs,
+    self,
+    utils,
+  }:
+  # We do this for all systems - namely x86_64-linux, aarch64-linux,
+  # x86_64-darwin and aarch64-darwin
+    utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      naersk-lib = pkgs.callPackage naersk {};
+    in rec {
+      # Build via nix build .#defaultPackage.x86_64-linux
+      defaultPackage = naersk-lib.buildPackage {
+        # The build dependencies
+        buildInputs = with pkgs; [pkg-config openssl];
+        src = ./.;
+      };
+
+      # Enter devshell with all the tools via "nix develop"
+      # or "nix-shell"
+      devShell = with pkgs;
+        mkShell {
+          buildInputs = [
+            actionlint
+            cargo
+            haskellPackages.hadolint
+            nodePackages_latest.cspell
+            nodePackages_latest.eslint
+            nodePackages_latest.markdownlint-cli2
+            nodePackages_latest.stylelint
+            nodePackages_latest.stylelint
+            rustPackages.clippy
+            rustc
+            yamllint
+          ];
+          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+        };
+
+      # Build via "nix build .#websurfx.x86_64-linux"
+      websurfx = defaultPackage;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       naersk-lib = pkgs.callPackage naersk {};
     in rec {
       # Build via nix build .#defaultPackage.x86_64-linux
-      defaultPackage = naersk-lib.buildPackage {
+      packages.default = naersk-lib.buildPackage {
         # The build dependencies
         buildInputs = with pkgs; [pkg-config openssl];
         src = ./.;
@@ -27,7 +27,7 @@
 
       # Enter devshell with all the tools via "nix develop"
       # or "nix-shell"
-      devShell = with pkgs;
+      devShells.default = with pkgs;
         mkShell {
           buildInputs = [
             actionlint
@@ -46,6 +46,6 @@
         };
 
       # Build via "nix build .#websurfx.x86_64-linux"
-      websurfx = defaultPackage;
+      packages.websurfx = packages.default;
     });
 }


### PR DESCRIPTION
## What does this PR do?

Adds a `flake.nix` and `flake.lock` to allow building this project quickly. After merging, this git repo may be used as a NixOS flake, enabling building/running websurfx via `nix build .#websurfx` / `nix run .#websurfx`.

Additionally, this adds a devshell with most of the linters this project uses included (usable via `nix develop`).

## Why is this change important?

Adds initial support for NixOS / Nix users.

## How to test this PR locally?

You need at least `nix` installed and `nix-command` and `flakes` enabled. Then:

~~~
nix build .#websurfx
nix run .#websurfx
~~~

This starts the application (minus Redis).

## Author's checklist

- [x]  fulfill additional requests
- [x]  check whether documentation example actually works
- [x]  bump version 

## Related Issues

Closes #229 