### PR TITLE
🛠️ Remove unused volume from yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - redis
     volumes:
       - ./websurfx/:/etc/xdg/websurfx/
-      - ./public/:/opt/websurfx/public/
   redis:
     image: redis:latest
     ports:


### PR DESCRIPTION
## What does this PR do?

This PR  removes the unused volume `public` from docker compose file

## Why is this change essential?

This change is essential as it removes an necessary step from the `docker compose` file.

## Related Issues
Closes #280 
