### PR TITLE
🔧 Remove the unused mapped ports for docker deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "websurfx"
-version = "1.0.9"
+version = "1.0.11"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.0.9"
+version = "1.0.11"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,3 @@ services:
   # Uncomment the following lines if you are using the `hybrid` or `redis` caching feature.
   # redis:
   #   image: redis:latest
-  #   ports:
-  #     - 6379:6379


### PR DESCRIPTION
## What does this PR do?
Removed the unused mapped ports for Docker deployment.

## Why is this change essential?
This change is essential as it removes unused ports for the docker deployment. 

## Related Issues
Closes #308 