### PR TITLE
🔧 Build arguments to make writing GitHub action for auto releasing new docker images easier 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 path = "src/bin/websurfx.rs"
 
 [dependencies]
-reqwest = {version="0.11.21",features=["json"]}
+reqwest = {version="0.11.21",default-features = false,features = ["json", "rustls-tls"]}
 tokio = {version="1.32.0",features=["rt-multi-thread","macros"]}
 serde = {version="1.0.188",features=["derive"]}
 handlebars = { version = "4.4.0", features = ["dir_source"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ description = "An open-source alternative to Searx that provides clean, ad-free,
 repository = "https://github.com/neon-mmd/websurfx"
 license = "AGPL-3.0"
 
+[[bin]]
+name = "websurfx"
+test = true
+bench = false
+path = "src/bin/websurfx.rs"
+
 [dependencies]
 reqwest = {version="0.11.21",features=["json"]}
 tokio = {version="1.32.0",features=["rt-multi-thread","macros"]}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,43 @@
-FROM rust:latest AS chef
+FROM --platform=$BUILDPLATFORM rust:1.73.0-alpine3.18 AS chef
 # We only pay the installation cost once,
 # it will be cached from the second build onwards
+RUN apk add --update alpine-sdk musl-dev g++ make libcrypto3 libressl-dev git upx perl build-base && rm -rf /var/cache/apk/*
 RUN cargo install cargo-chef --locked
 
 WORKDIR /app
 
 FROM chef AS planner
-COPY . . 
+COPY ./Cargo.toml ./Cargo.lock ./
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM chef AS builder
+FROM --platform=$BUILDPLATFORM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-# Build dependencies - this is the caching Docker layer!
-# Uncomment the line below if you want to use the `hybrid` caching feature.
-# RUN cargo chef cook --release --features redis-cache --recipe-path recipe.json
-# Comment the line below if you don't want to use the `In-Memory` caching feature.
-RUN cargo chef cook --release --recipe-path recipe.json
-# Uncomment the line below if you want to use the `no cache` feature.
-# RUN cargo chef cook --release --no-default-features --recipe-path recipe.json
-# Uncomment the line below if you want to use the `redis` caching feature.
-# RUN cargo chef cook --release --no-default-features --features redis-cache --recipe-path recipe.json
+# Specify the cache type to use (memory, redis, hybrid, no-cache)
+ARG CACHE=memory
+ENV CACHE=${CACHE}
+# Cook the dependencies
+RUN export ARCH=$(uname -m) && \
+  if [ "$CACHE" = "memory" ] ; then cargo chef cook --release --target=$ARCH-unknown-linux-musl --recipe-path recipe.json ; \
+  else if [ "$CACHE" = "redis" ] ; then cargo chef cook --release --target=$ARCH-unknown-linux-musl --no-default-features --features redis-cache --recipe-path recipe.json ; \
+  else if [ "$CACHE" = "hybrid" ] ; then cargo chef cook --release --target=$ARCH-unknown-linux-musl --features redis-cache --recipe-path recipe.json ; \
+  else if [ "$CACHE" = "no-cache" ] ; then cargo chef cook --release --target=$ARCH-unknown-linux-musl --no-default-features --recipe-path recipe.json ; fi ; fi ; fi ; fi
+# Copy the source code and public folder
+COPY ./src ./src
+COPY ./public ./public
+# Build the application
+RUN export ARCH=$(uname -m) && \
+  if [ "$CACHE" = "memory" ] ; then cargo build --release --target=$ARCH-unknown-linux-musl ; \
+  else if [ "$CACHE" = "redis" ] ; then cargo build --release --target=$ARCH-unknown-linux-musl --no-default-features --features redis-cache ; \
+  else if [ "$CACHE" = "hybrid" ] ; then cargo build --release --target=$ARCH-unknown-linux-musl --features redis-cache ; \
+  else if [ "$CACHE" = "no-cache" ] ; then cargo build --release --target=$ARCH-unknown-linux-musl --no-default-features ; fi ; fi ; fi ; fi
+# Optimise binary size with UPX
+RUN export ARCH=$(uname -m) \
+  && upx --lzma --best /app/target/$ARCH-unknown-linux-musl/release/websurfx \
+  && cp /app/target/$ARCH-unknown-linux-musl/release/websurfx /usr/local/bin/websurfx
 
-# Build application
-COPY . .
-# Uncomment the line below if you want to use the `hybrid` caching feature.
-# RUN cargo install --path . --features redis-cache
-# Comment the line below if you don't want to use the `In-Memory` caching feature.
-RUN cargo install --path .
-# Uncomment the line below if you want to use the `no cache` feature.
-# RUN cargo install --path . --no-default-features 
-# Uncomment the line below if you want to use the `redis` caching feature.
-# RUN cargo install --path . --no-default-features --features redis-cache
 
-# We do not need the Rust toolchain to run the binary!
-FROM gcr.io/distroless/cc-debian12
+FROM --platform=$BUILDPLATFORM scratch
 COPY --from=builder /app/public/ /opt/websurfx/public/
 VOLUME ["/etc/xdg/websurfx/"]
-COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/
+COPY --from=builder /usr/local/bin/websurfx /usr/local/bin/websurfx
 CMD ["websurfx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=$BUILDPLATFORM rust:1.73.0-alpine3.18 AS chef
 # We only pay the installation cost once,
 # it will be cached from the second build onwards
-RUN apk add --update alpine-sdk musl-dev g++ make libcrypto3 libressl-dev git upx perl build-base && rm -rf /var/cache/apk/*
+RUN apk add --no-cache alpine-sdk musl-dev g++ make libcrypto3 libressl-dev upx perl build-base
 RUN cargo install cargo-chef --locked
 
 WORKDIR /app


### PR DESCRIPTION
## What does this PR do?

This change the `Dockerfile` to enable different architecture and build args to select the cache type.
Some problem with cargo chef cache also got fix.
I also optimised the image to be smaller then before using musl as target and upx with a scratch image.
The final result is ~98% smaller then originally.

## Why is this change important?

It will be easier to create a github workflow to release docker image for different architecture and cache type.

## How to test this PR locally?

You can build the image using docker, this is the command i used:

```sh
docker build --build-arg CACHE=redis -t websurfx:1.0.14 .
```

## Author's checklist

I'm not quite sure what to add on this section, but i'll join a screenshot of the new image size.

![image](https://github.com/neon-mmd/websurfx/assets/7750950/fc9255e9-2710-46e3-814a-63fb99ad1f70)


## Related issues

Closes #322
Closes #321 