### PR TITLE
🔧 Restricts the visibility of the `user-agent` helper module

### DIFF
--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -3,4 +3,4 @@
 //! provides various models to aggregate search results into a standardized form.
 
 pub mod aggregator;
-pub mod user_agent;
+mod user_agent;


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

Restricts the visibility of the user-agent helper module by removing the `pub` keyword in the` mod.rs` file located in `src/results/ `directory under the codebase (websurfx directory).


## Why is this change important?

<!-- MANDATORY -->

Restricts the visibility of the user-agent helper module

## Related issues

<!--
Closes #234 
-->

Closes #330 


