### PR TITLE
🔧 Remove the unnecessary clone call on user-agent `&str`  variable

### DIFF
--- a/src/results/aggregator.rs
+++ b/src/results/aggregator.rs
@@ -88,13 +88,7 @@ pub async fn aggregate(
         let query: String = query.to_owned();
         tasks.push(tokio::spawn(async move {
             search_engine
-                .results(
-                    &query,
-                    page,
-                    user_agent.clone(),
-                    request_timeout,
-                    safe_search,
-                )
+                .results(&query, page, user_agent, request_timeout, safe_search)
                 .await
         }));
     }


### PR DESCRIPTION
## What does this PR do?

Removes the unnecessary clone call on user-agent &str variable.

## Why is this change important?

The user-agent `&str` variable does not implement the clone trait and implements the copy trait. So calling the clone call on it does no operation on the variable.

## Related issues

Closes #332 

