### PR TITLE
✨ `Brave` for the search engine

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,10 +1,10 @@
 {  
- "extends": "stylelint-config-standard",
+  "extends": "stylelint-config-standard",
   "rules": {
     "alpha-value-notation": "number",
     "selector-class-pattern": null
   },
-"overrides": [
+  "overrides": [
     {
       "files": ["*.js"],
       "customSyntax": "postcss-lit"

--- a/src/engines/brave.rs
+++ b/src/engines/brave.rs
@@ -62,7 +62,7 @@ impl SearchEngine for Brave {
             ("REFERER".to_string(), "https://google.com/".to_string()),
             (
                 "COOKIE".to_string(),
-                format!("safe_search={}", safe_search_level),
+                format!("safe_search={safe_search_level}"),
             ),
         ]))
         .change_context(EngineError::UnexpectedError)?;

--- a/src/engines/brave.rs
+++ b/src/engines/brave.rs
@@ -49,7 +49,7 @@ impl SearchEngine for Brave {
 
         let safe_search_level = match safe_search {
             0 => "off",
-            1 | 2 => "moderate",
+            1 => "moderate",
             _ => "strict",
         };
 

--- a/src/engines/brave.rs
+++ b/src/engines/brave.rs
@@ -1,0 +1,84 @@
+//! The `brave` module handles the scraping of results from the brave search engine
+//! by querying the upstream brave search engine with user provided query and with a page
+//! number if provided.
+
+use std::collections::HashMap;
+
+use reqwest::header::HeaderMap;
+use scraper::Html;
+
+use crate::models::aggregation_models::SearchResult;
+use error_stack::{Report, Result, ResultExt};
+
+use crate::models::engine_models::{EngineError, SearchEngine};
+
+use super::search_result_parser::SearchResultParser;
+
+/// Scrapes the results from the Brave search engine.  
+pub struct Brave {
+    /// Utilises generic logic for parsing search results.
+    parser: SearchResultParser,
+}
+
+impl Brave {
+    /// Creates the Brave parser.
+    pub fn new() -> Result<Brave, EngineError> {
+        Ok(Self {
+            parser: SearchResultParser::new(
+                "#results h4",
+                "#results [data-pos]",
+                "a > .url",
+                "a",
+                ".snippet-description",
+            )?,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl SearchEngine for Brave {
+    async fn results(
+        &self,
+        query: &str,
+        page: u32,
+        user_agent: &str,
+        request_timeout: u8,
+        _safe_search: u8,
+    ) -> Result<HashMap<String, SearchResult>, EngineError> {
+        let url = format!("https://search.brave.com/search?q={query}&offset={page}");
+
+        let header_map = HeaderMap::try_from(&HashMap::from([
+            ("USER_AGENT".to_string(), user_agent.to_string()),
+            (
+                "CONTENT_TYPE".to_string(),
+                "application/x-www-form-urlencoded".to_string(),
+            ),
+        ]))
+        .change_context(EngineError::UnexpectedError)?;
+
+        let document: Html = Html::parse_document(
+            &Brave::fetch_html_from_upstream(self, &url, header_map, request_timeout).await?,
+        );
+
+        if let Some(no_result_msg) = self.parser.parse_for_no_results(&document).nth(0) {
+            if no_result_msg
+                .inner_html()
+                .contains("Not many great matches came back for your search")
+            {
+                return Err(Report::new(EngineError::EmptyResultSet));
+            }
+        }
+
+        self.parser
+            .parse_for_results(&document, |title, url, desc| {
+                url.value().attr("href").map(|url| {
+                    SearchResult::new(
+                        title.text().collect::<Vec<_>>().join("").trim(),
+                        url.trim(),
+                        desc.inner_html().trim(),
+                        &["brave"],
+                    )
+                })
+            })
+    }
+}

--- a/src/engines/brave.rs
+++ b/src/engines/brave.rs
@@ -43,15 +43,26 @@ impl SearchEngine for Brave {
         page: u32,
         user_agent: &str,
         request_timeout: u8,
-        _safe_search: u8,
+        safe_search: u8,
     ) -> Result<HashMap<String, SearchResult>, EngineError> {
         let url = format!("https://search.brave.com/search?q={query}&offset={page}");
+
+        let safe_search_level = match safe_search {
+            0 => "off",
+            1 | 2 => "moderate",
+            _ => "strict",
+        };
 
         let header_map = HeaderMap::try_from(&HashMap::from([
             ("USER_AGENT".to_string(), user_agent.to_string()),
             (
                 "CONTENT_TYPE".to_string(),
                 "application/x-www-form-urlencoded".to_string(),
+            ),
+            ("REFERER".to_string(), "https://google.com/".to_string()),
+            (
+                "COOKIE".to_string(),
+                format!("safe_search={}", safe_search_level),
             ),
         ]))
         .change_context(EngineError::UnexpectedError)?;

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -3,6 +3,7 @@
 //! provide a standard functions to be implemented for all the upstream search engine handling
 //! code. Moreover, it also provides a custom error for the upstream search engine handling code.
 
+pub mod brave;
 pub mod duckduckgo;
 pub mod search_result_parser;
 pub mod searx;

--- a/src/models/engine_models.rs
+++ b/src/models/engine_models.rs
@@ -150,6 +150,10 @@ impl EngineHandler {
                     let engine = crate::engines::searx::Searx::new()?;
                     ("searx", Box::new(engine))
                 }
+                "brave" => {
+                    let engine = crate::engines::brave::Brave::new()?;
+                    ("brave", Box::new(engine))
+                }
                 _ => {
                     return Err(Report::from(EngineError::NoSuchEngineFound(
                         engine_name.to_string(),

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -52,4 +52,5 @@ redis_url = "redis://127.0.0.1:8082" -- redis connection url address on which th
 upstream_search_engines = {
 	DuckDuckGo = true,
 	Searx = false,
+	Brave = false,
 } -- select the upstream search engines from which the results should be fetched.


### PR DESCRIPTION
## What does this PR do?

Implements `Brave` source of search results.

## Why is this change important?

Allows users to search using `Brave` search engine.

## How to test this PR locally?

Edit `config.lua` file to enable `Brave` source:
```lua
    ...
    Brave = true,
    ...
```
Run app: https://github.com/neon-mmd/websurfx#installation-and-testing-%EF%B8%8F

## Related issues

Closes #319 
