### PR TITLE
📝 Typo correction in the `developing` documentation page

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -383,7 +383,7 @@ Once you have finished running the above command, Websurfx should now be served 
 
 ### Environment Variables
 
-All environmental variables are optional. Currently there are not many environmental variables used, as most of the user preferences are stored under the `websurfx` folder (located under the codebase (`websurfx` directory)) in the `config.lua` file.
+All environment variables are optional. Currently there are not many environment variables used, as most of the user preferences are stored under the `websurfx` folder (located under the codebase (`websurfx` directory)) in the `config.lua` file.
 
 The list of all the available environment variables are listed down below:
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes the typo in the developing documentation page.

## Why is the change essential?
This change is essential as it fixes the typo in the documentation which improves the readablility of the docs.

## Related Issues
Closes #352