### PR TITLE
✨ Config option to customize the cache invalidation/expiry time

### DIFF
--- a/src/cache/cacher.rs
+++ b/src/cache/cacher.rs
@@ -79,7 +79,7 @@ impl Cacher for RedisCache {
             "Initialising redis cache. Listening to {}",
             &config.redis_url
         );
-        RedisCache::new(&config.redis_url, 5)
+        RedisCache::new(&config.redis_url, 5, config.cache_expiry_time)
             .await
             .expect("Redis cache configured")
     }
@@ -113,13 +113,12 @@ pub struct InMemoryCache {
 #[cfg(feature = "memory-cache")]
 #[async_trait::async_trait]
 impl Cacher for InMemoryCache {
-    async fn build(_config: &Config) -> Self {
+    async fn build(config: &Config) -> Self {
         log::info!("Initialising in-memory cache");
 
         InMemoryCache {
             cache: MokaCache::builder()
-                .max_capacity(1000)
-                .time_to_live(Duration::from_secs(60))
+                .time_to_live(Duration::from_secs(config.cache_expiry_time.into()))
                 .build(),
         }
     }

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -21,6 +21,9 @@ pub struct Config {
     /// It stores the redis connection url address on which the redis
     /// client should connect.
     pub redis_url: String,
+    #[cfg(any(feature = "redis-cache", feature = "memory-cache"))]
+    /// It stores the max TTL for search results in cache.
+    pub cache_expiry_time: u16,
     /// It stores the option to whether enable or disable production use.
     pub aggregator: AggregatorConfig,
     /// It stores the option to whether enable or disable logs.
@@ -93,6 +96,19 @@ impl Config {
             }
         };
 
+        #[cfg(any(feature = "redis-cache", feature = "memory-cache"))]
+        let parsed_cet = globals.get::<_, u16>("cache_expiry_time")?;
+        let cache_expiry_time = match parsed_cet {
+            0..=59 => {
+                log::error!(
+                    "Config Error: The value of `cache_expiry_time` must be greater than 60"
+                );
+                log::error!("Falling back to using the value `60` for the option");
+                60
+            }
+            _ => parsed_cet,
+        };
+
         Ok(Config {
             port: globals.get::<_, u16>("port")?,
             binding_ip: globals.get::<_, String>("binding_ip")?,
@@ -116,6 +132,8 @@ impl Config {
                 time_limit: rate_limiter["time_limit"],
             },
             safe_search,
+            #[cfg(any(feature = "redis-cache", feature = "memory-cache"))]
+            cache_expiry_time,
         })
     }
 }

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -47,7 +47,7 @@ theme = "simple" -- the theme name which should be used for the website
 
 -- ### Caching ###
 redis_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
-
+cache_expiry_time = 600 -- This option takes the expiry time of the search results (value in seconds and the value should be greater than or equal to 60 seconds).
 -- ### Search Engines ###
 upstream_search_engines = {
 	DuckDuckGo = true,


### PR DESCRIPTION
## What does this PR do?

Provides a new config option `cache_expiry_time`. 

## Why is this change important?

Allows the admin to set TTL (time to live) value for cached search results. 

## Related issues

Closes #402

