### PR TITLE
🎨 Restructure search engine backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1051,6 +1052,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4077,6 +4098,7 @@ dependencies = [
  "blake3",
  "criterion",
  "dhat",
+ "enumflags2",
  "env_logger",
  "error-stack",
  "fake-useragent",
@@ -4097,6 +4119,7 @@ dependencies = [
  "serde_json",
  "smallvec 1.11.2",
  "tempfile",
+ "time 0.3.30",
  "tokio 1.34.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 path = "src/bin/websurfx.rs"
 
 [dependencies]
-reqwest = {version="0.11.22", default-features=false, features=["rustls-tls","brotli", "gzip"]}
+reqwest = {version="0.11.22", default-features=false, features=["rustls-tls","brotli", "gzip", "json"]}
 tokio = {version="1.32.0",features=["rt-multi-thread","macros"], default-features = false}
 serde = {version="1.0.190", default-features=false, features=["derive"]}
 serde_json = {version="1.0.108", default-features=false}
@@ -38,6 +38,8 @@ mimalloc = { version = "0.1.38", default-features = false }
 async-once-cell = {version="0.5.3", default-features=false}
 actix-governor = {version="0.5.0", default-features=false}
 mini-moka = { version="0.10", optional = true, default-features=false, features=["sync"]}
+enumflags2 = "0.7.8"
+time ={version = "0.3.30", features = ["serde-human-readable"]}
 
 [dev-dependencies]
 rusty-hook = {version="^0.11.2", default-features=false}

--- a/src/cache/error.rs
+++ b/src/cache/error.rs
@@ -47,4 +47,4 @@ impl fmt::Display for CacheError {
     }
 }
 
-impl error_stack::Context for CacheError {}
+impl std::error::Error for CacheError {}

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -85,7 +85,7 @@ impl Config {
 
         let rate_limiter = globals.get::<_, HashMap<String, u8>>("rate_limiter")?;
 
-        let mut request_client = globals.get::<_, HashMap<String, String>>("request_client")?;
+        let request_client = globals.get::<_, HashMap<String, String>>("request_client")?;
 
         let parsed_safe_search: u8 = globals.get::<_, u8>("safe_search")?;
         let safe_search: u8 = match parsed_safe_search {

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -3,7 +3,7 @@
 
 use crate::handler::{file_path, FileType};
 
-use crate::models::parser_models::{AggregatorConfig, RateLimiter, Style};
+use crate::models::parser_models::{AggregatorConfig, RateLimiter, RequestClientConfig, Style};
 use log::LevelFilter;
 use mlua::Lua;
 use std::{collections::HashMap, fs, thread::available_parallelism};
@@ -38,6 +38,8 @@ pub struct Config {
     /// It stores the level of safe search to be used for restricting content in the
     /// search results.
     pub safe_search: u8,
+    /// It stores config for the http client which sends requests to upstream servers.
+    pub request_client: RequestClientConfig,
 }
 
 impl Config {
@@ -83,6 +85,8 @@ impl Config {
 
         let rate_limiter = globals.get::<_, HashMap<String, u8>>("rate_limiter")?;
 
+        let mut request_client = globals.get::<_, HashMap<String, String>>("request_client")?;
+
         let parsed_safe_search: u8 = globals.get::<_, u8>("safe_search")?;
         let safe_search: u8 = match parsed_safe_search {
             0..=4 => parsed_safe_search,
@@ -116,6 +120,7 @@ impl Config {
                 time_limit: rate_limiter["time_limit"],
             },
             safe_search,
+            request_client: request_client.try_into()?,
         })
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,91 @@
+use std::{collections::HashMap, sync::Arc};
+
+use crate::models::{
+    aggregation_models::SearchResult,
+    client_models::HttpClient,
+    engine_models::{EngineError, EngineErrorType, SearchEngine},
+};
+use actix_web::rt::spawn;
+use error_stack::Report;
+use error_stack::Result;
+
+pub struct EngineHandler {
+    engines: Arc<Vec<Arc<Box<dyn SearchEngine>>>>,
+    client: Arc<HttpClient>,
+}
+
+pub type RawResults = Vec<Result<HashMap<String, SearchResult>, EngineError>>;
+
+impl EngineHandler {
+    /// Parses names of engines and initialises them for use.
+    ///
+    /// # Arguments
+    ///
+    /// * `engine_names - It takes the names of the engines.
+    ///
+    /// # Returns
+    ///
+    /// It returns an option either containing the value or a none if the engine is unknown
+    pub fn new(engine_names: Vec<String>, client: HttpClient) -> Result<Self, EngineError> {
+        let mut engines: Vec<Arc<Box<dyn SearchEngine>>> = vec![];
+
+        for engine_name in engine_names {
+            let engine: Box<dyn SearchEngine> = match engine_name.to_lowercase().as_str() {
+                "duckduckgo" => Box::new(crate::engines::duckduckgo::DuckDuckGo::new()?),
+                "searx" => Box::new(crate::engines::searx::Searx::new()?),
+                "brave" => Box::new(crate::engines::brave::Brave::new()?),
+                _ => {
+                    return Err(Report::from(EngineError {
+                        error_type: EngineErrorType::NoSuchEngineFound,
+                        engine: engine_name.to_string(),
+                    }))
+                }
+            };
+            engines.push(Arc::new(engine));
+        }
+
+        Ok(Self {
+            engines: Arc::new(engines),
+            client: Arc::new(client)
+        })
+    }
+
+    pub async fn search(
+        &self,
+        engine_names: Option<Vec<String>>,
+        query: &str,
+        // category: QueryType,
+        // query_relevance: Option<QueryRelavancy>,
+        page: u32,
+        safe_search: u8,
+    ) -> RawResults {
+        let mut tasks = Vec::with_capacity(self.engines.len());
+        for engine in &*self.engines {
+            if let Some(ref engine_names) = engine_names {
+                // TODO: Handle invalid engine names provided by the user, currently it silently ignores
+                if !engine_names.contains(&engine.get_name().to_owned()) {
+                    continue;
+                }
+            }
+            let engine = engine.clone();
+            // let query_relevance = query_relevance.clone();
+            let client = self.client.clone();
+            let query = query.to_owned();
+            tasks.push(spawn(async move {
+                engine
+                    .fetch_results(&query, page, client, safe_search)
+                    .await
+            }));
+        }
+
+        let mut responses = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            // An error will only be raised when the task panics, here it should technically never panic
+            if let Ok(result) = task.await {
+                responses.push(result);
+            }
+        }
+
+        responses
+    }
+}

--- a/src/engines/searx.rs
+++ b/src/engines/searx.rs
@@ -3,14 +3,16 @@
 //! number if provided.
 
 use reqwest::header::HeaderMap;
-use reqwest::Client;
+
 use scraper::Html;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::search_result_parser::SearchResultParser;
 use crate::models::aggregation_models::SearchResult;
-use crate::models::engine_models::{EngineError, SearchEngine};
-use error_stack::{Report, Result, ResultExt};
+use crate::models::client_models::HttpClient;
+use crate::models::engine_models::{EngineError, EngineErrorType, QueryType, SearchEngine};
+use error_stack::{Result, ResultExt};
 
 /// A new Searx engine type defined in-order to implement the `SearchEngine` trait which allows to
 /// reduce code duplication as well as allows to create vector of different search engines easily.
@@ -29,19 +31,32 @@ impl Searx {
                 "h3>a",
                 "h3>a",
                 ".content",
-            )?,
+            )
+            .change_context(EngineError {
+                error_type: EngineErrorType::UnexpectedError,
+                engine: "searx".to_string(),
+            })?,
         })
     }
 }
 
 #[async_trait::async_trait]
 impl SearchEngine for Searx {
-    async fn results(
+    fn get_name(&self) -> &'static str {
+        "searx"
+    }
+
+    fn get_query_types(&self) -> QueryType {
+        QueryType::Text
+    }
+
+    async fn fetch_results(
         &self,
         query: &str,
+        // category: QueryType,
+        // query_relevance: Option<QueryRelavancy>,
         page: u32,
-        user_agent: &str,
-        client: &Client,
+        client: Arc<HttpClient>,
         mut safe_search: u8,
     ) -> Result<HashMap<String, SearchResult>, EngineError> {
         // Page number can be missing or empty string and so appropriate handling is required
@@ -61,27 +76,40 @@ impl SearchEngine for Searx {
 
         // initializing headers and adding appropriate headers.
         let header_map = HeaderMap::try_from(&HashMap::from([
-            ("USER_AGENT".to_string(), user_agent.to_string()),
             ("REFERER".to_string(), "https://google.com/".to_string()),
             ("CONTENT_TYPE".to_string(), "application/x-www-form-urlencoded".to_string()),
             ("COOKIE".to_string(), "categories=general; language=auto; locale=en; autocomplete=duckduckgo; image_proxy=1; method=POST; safesearch=2; theme=simple; results_on_new_tab=1; doi_resolver=oadoi.org; simple_style=auto; center_alignment=1; query_in_title=1; infinite_scroll=0; disabled_engines=; enabled_engines=\"archive is__general\\054yep__general\\054curlie__general\\054currency__general\\054ddg definitions__general\\054wikidata__general\\054duckduckgo__general\\054tineye__general\\054lingva__general\\054startpage__general\\054yahoo__general\\054wiby__general\\054marginalia__general\\054alexandria__general\\054wikibooks__general\\054wikiquote__general\\054wikisource__general\\054wikiversity__general\\054wikivoyage__general\\054dictzone__general\\054seznam__general\\054mojeek__general\\054naver__general\\054wikimini__general\\054brave__general\\054petalsearch__general\\054goo__general\"; disabled_plugins=; enabled_plugins=\"searx.plugins.hostname_replace\\054searx.plugins.oa_doi_rewrite\\054searx.plugins.vim_hotkeys\"; tokens=; maintab=on; enginetab=on".to_string())
         ]))
-        .change_context(EngineError::UnexpectedError)?;
+        .change_context(EngineError {
+            error_type: EngineErrorType::UnexpectedError,
+            engine: self.get_name().to_string(),
+        })?;
 
         let document: Html = Html::parse_document(
-            &Searx::fetch_html_from_upstream(self, &url, header_map, client).await?,
+            &client
+                .fetch_html(&url, header_map, None)
+                .await
+                .change_context(EngineError {
+                    error_type: EngineErrorType::RequestError,
+                    engine: self.get_name().to_string(),
+                })?,
         );
 
         if let Some(no_result_msg) = self.parser.parse_for_no_results(&document).nth(1) {
             if no_result_msg.inner_html()
             == "we didn't find any results. Please use another query or search in more categories"
         {
-            return Err(Report::new(EngineError::EmptyResultSet));
+            return Err(EngineError {
+                    error_type: EngineErrorType::EmptyResultSet,
+                    engine: self.get_name().to_string(),
+                }
+                .into());
         }
         }
 
         // scrape all the results from the html
-        self.parser
+        Ok(self
+            .parser
             .parse_for_results(&document, |title, url, desc| {
                 url.value().attr("href").map(|url| {
                     SearchResult::new(
@@ -91,6 +119,6 @@ impl SearchEngine for Searx {
                         &["searx"],
                     )
                 })
-            })
+            }))
     }
 }

--- a/src/models/client_models.rs
+++ b/src/models/client_models.rs
@@ -1,0 +1,33 @@
+//! This module provides the public models for handling web requests made by engines to upstream search engines.
+
+use std::time::Duration;
+
+use crate::config::parser::Config;
+use reqwest::{Client as rClient, ClientBuilder, redirect::Policy, Proxy};
+
+pub struct Client(rClient);
+
+impl Client {
+    pub fn new(config: Config) -> Result<Self, Box<dyn std::error::Error>> {
+        let config = config.request_client;
+
+        let client = ClientBuilder::new()
+            .timeout(Duration::from_secs(config.timeout.into()))
+            .https_only(config.https_only)
+            .redirect(Policy::limited(config.max_redirects.into()))
+            .gzip(true)
+            .brotli(true);
+        
+        if !config.use_http2{
+            let client = client.http1_only();
+        }
+        
+        if let Some(p_url) = config.proxy_url{
+            let proxy = Proxy::all(p_url)?;
+            let client = client.proxy(proxy);
+        }
+        
+        Ok(Client(client.build()?))
+    }
+    
+}

--- a/src/models/client_models.rs
+++ b/src/models/client_models.rs
@@ -1,15 +1,48 @@
 //! This module provides the public models for handling web requests made by engines to upstream search engines.
 
-use std::time::Duration;
+use error_stack::{Result, ResultExt};
+use std::{fmt::Display, time::Duration};
 
 use crate::config::parser::Config;
-use reqwest::{Client as rClient, ClientBuilder, redirect::Policy, Proxy};
+use reqwest::{redirect::Policy, Client, ClientBuilder, Proxy, Response};
 
-pub struct Client(rClient);
+#[derive(Debug)]
+pub enum ClientError {
+    /// Raised when a web request is failed.
+    RequestError,
+    /// Raised when the proxy url is invalid.
+    InvalidProxy,
+    /// Raised when the proxy is marked as tor enabled but is not routing the requests
+    /// through tor exit nodes.
+    TorInactive,
+    /// Raised when the client builder faces an error
+    UnexpectedError,
+    /// Raised when response could not be serialized.
+    SerializationError,
+}
 
-impl Client {
-    pub fn new(config: Config) -> Result<Self, Box<dyn std::error::Error>> {
-        let config = config.request_client;
+impl Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::RequestError => {
+                write!(f, "Request client couldn't complete the request.")
+            }
+            ClientError::InvalidProxy => write!(f, "The provided proxy url is invalid"),
+            ClientError::TorInactive => write!(f, "Proxy is not using tor exit nodes"),
+            ClientError::UnexpectedError => write!(f, "Unexpected client error occured"),
+            ClientError::SerializationError => write!(f, "Unable to deserialise response"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+#[derive(Clone)]
+pub struct HttpClient(Client);
+
+impl HttpClient {
+    pub fn new(config: &Config) -> Result<Self, ClientError> {
+        let config = config.request_client.clone();
 
         let client = ClientBuilder::new()
             .timeout(Duration::from_secs(config.timeout.into()))
@@ -17,17 +50,71 @@ impl Client {
             .redirect(Policy::limited(config.max_redirects.into()))
             .gzip(true)
             .brotli(true);
-        
-        if !config.use_http2{
-            let client = client.http1_only();
-        }
-        
-        if let Some(p_url) = config.proxy_url{
-            let proxy = Proxy::all(p_url)?;
-            let client = client.proxy(proxy);
-        }
-        
-        Ok(Client(client.build()?))
+
+        let client = if !config.use_http2 {
+            client.http1_only()
+        } else {
+            client
+        };
+
+        let client = if let Some(p_url) = config.proxy_url {
+            let proxy = Proxy::all(p_url).change_context(ClientError::InvalidProxy)?;
+            client.proxy(proxy)
+        } else {
+            client
+        };
+
+        Ok(HttpClient(
+            client
+                .build()
+                .change_context(ClientError::UnexpectedError)?,
+        ))
     }
-    
+
+    // TODO: Should this be made public?
+    async fn fetch(
+        &self,
+        url: &str,
+        header_map: reqwest::header::HeaderMap,
+        timeout: Option<u8>,
+    ) -> Result<Response, ClientError> {
+        let client = self.0.get(url).headers(header_map);
+
+        let client = if let Some(timeout) = timeout {
+            client.timeout(Duration::from_secs(timeout.into()))
+        } else {
+            client
+        };
+
+        client // add spoofed headers to emulate human behavior
+            .send()
+            .await
+            .change_context(ClientError::RequestError)
+    }
+
+    pub async fn fetch_html(
+        &self,
+        url: &str,
+        header_map: reqwest::header::HeaderMap,
+        timeout: Option<u8>,
+    ) -> Result<String, ClientError> {
+        self.fetch(url, header_map, timeout)
+            .await?
+            .text()
+            .await
+            .change_context(ClientError::RequestError)
+    }
+
+    pub async fn fetch_json(
+        &self,
+        url: &str,
+        header_map: reqwest::header::HeaderMap,
+        timeout: Option<u8>,
+    ) -> Result<String, ClientError> {
+        self.fetch(url, header_map, timeout)
+            .await?
+            .json()
+            .await
+            .change_context(ClientError::SerializationError)
+    }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,7 +3,7 @@
 //! custom engine error for the search engine, etc.
 
 pub mod aggregation_models;
+pub mod client_models;
 pub mod engine_models;
 pub mod parser_models;
 pub mod server_models;
-pub mod client_models;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,3 +6,4 @@ pub mod aggregation_models;
 pub mod engine_models;
 pub mod parser_models;
 pub mod server_models;
+pub mod client_models;

--- a/src/models/parser_models.rs
+++ b/src/models/parser_models.rs
@@ -72,7 +72,7 @@ impl TryFrom<HashMap<String, String>> for RequestClientConfig {
         };
 
         let is_tor_proxy = value.get("is_tor_proxy").map(|s| {
-            bool_parse(&s).unwrap_or_else(|_| {
+            bool_parse(s).unwrap_or_else(|_| {
                 log::error!("Config Error: The value of `is_tor_proxy` option should be a boolean");
                 log::error!("Falling back to using the value `false` for the option");
                 false
@@ -93,14 +93,13 @@ impl TryFrom<HashMap<String, String>> for RequestClientConfig {
         };
 
         Ok(RequestClientConfig {
-                    proxy_url: value.get("proxy_url").and_then(|s| Some(s.clone())),
-                    is_tor_proxy,
-                    https_only,
-                    use_http2: value["use_http2"].parse()?,
-                    timeout: value["timeout"].parse()?,
-                    max_retries: value["max_retries"].parse()?,
-                    max_redirects: value["max_redirects"].parse()?,
-                })
+            proxy_url: value.get("proxy_url").cloned(),
+            is_tor_proxy,
+            https_only,
+            use_http2: value["use_http2"].parse()?,
+            timeout: value["timeout"].parse()?,
+            max_retries: value["max_retries"].parse()?,
+            max_redirects: value["max_redirects"].parse()?,
+        })
     }
-
 }

--- a/src/models/parser_models.rs
+++ b/src/models/parser_models.rs
@@ -1,6 +1,8 @@
 //! This module provides public models for handling, storing and serializing parsed config file
 //! options from config.lua by grouping them together.
 
+use std::collections::HashMap;
+
 /// A named struct which stores,deserializes, serializes and groups the parsed config file options
 /// of theme and colorscheme names into the Style struct which derives the `Clone`, `Serialize`
 /// and Deserialize traits where the `Clone` trait is derived for allowing the struct to be
@@ -47,4 +49,58 @@ pub struct RateLimiter {
     pub number_of_requests: u8,
     /// The time limit in which the quantity of requests that should be accepted.
     pub time_limit: u8,
+}
+
+#[derive(Clone)]
+pub struct RequestClientConfig {
+    pub proxy_url: Option<String>,
+    pub is_tor_proxy: Option<bool>,
+    pub use_http2: bool,
+    pub https_only: bool,
+    pub timeout: u8,
+    pub max_retries: u8,
+    pub max_redirects: u8,
+}
+
+impl TryFrom<HashMap<String, String>> for RequestClientConfig {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(value: HashMap<String, String>) -> Result<Self, Self::Error> {
+        let bool_parse = |s| match s {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            _ => Err(()),
+        };
+
+        let is_tor_proxy = value.get("is_tor_proxy").map(|s| {
+            bool_parse(&s).unwrap_or_else(|_| {
+                log::error!("Config Error: The value of `is_tor_proxy` option should be a boolean");
+                log::error!("Falling back to using the value `false` for the option");
+                false
+            })
+        });
+
+        let https_only = match value.get("https_only") {
+            Some(v) => bool_parse(v).unwrap_or_else(|_| {
+                log::error!("Config Error: The value of https_only` option should be a boolean.");
+                log::error!("Falling back to using the value `true` for the option");
+                true
+            }),
+            None => {
+                log::error!("Config Error: The value of https_only` option is not set");
+                log::error!("Falling back to using the value `true` for the option");
+                true
+            }
+        };
+
+        Ok(RequestClientConfig {
+                    proxy_url: value.get("proxy_url").and_then(|s| Some(s.clone())),
+                    is_tor_proxy,
+                    https_only,
+                    use_http2: value["use_http2"].parse()?,
+                    timeout: value["timeout"].parse()?,
+                    max_retries: value["max_retries"].parse()?,
+                    max_redirects: value["max_redirects"].parse()?,
+                })
+    }
+
 }

--- a/src/templates/views/search.rs
+++ b/src/templates/views/search.rs
@@ -33,8 +33,8 @@ pub fn search(
               @if !search_results.results.is_empty() {
                   @for result in search_results.results.iter(){
                       .result {
-                         h1{a href=(result.url){(PreEscaped(&result.title))}}
-                         small{(result.url)}
+                         h1{a href=(result.page_url){(PreEscaped(&result.title))}}
+                         small{(result.page_url)}
                          p{(PreEscaped(&result.description))}
                          .upstream_engines{
                             @for name in result.clone().engine{

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -15,6 +15,16 @@ rate_limiter = {
 	time_limit = 3, -- The time limit in which the quantity of requests that should be accepted.
 }
 
+request_client = {
+	-- proxy_url =""
+	-- is_tor_proxy = "false"
+	use_http2 = "true",
+	https_only = "true",
+	timeout = "5",
+	max_retries = "3",
+	max_redirects = "3"
+}
+
 -- ### Search ###
 -- Filter results based on different levels. The levels provided are:
 -- {{


### PR DESCRIPTION
## What does this PR do?

This PR does the following:
- Repurposed the`EngineHandler` struct to schedule and handle engine execution and related processes
- Introduced `Ranker` struct to handle result aggregation and ranking.
- Introduced the `HttpClient` struct meant to handle all the http requests made and added configuration for it.
- Introduce new methods for `SearchEngine` trait to get metadata about engine. (`get_query_types`, `get_name`)
- Added enums to support more options to go with query (Relavancy and Type) (Not implemented in functions as of now).
- Made error handling a bit more concise.

## Why is this change important?

This PR is decouples the components of backend and also allow for future extension of the objects.

## How to test this PR locally?

`cargo run`

## Author's checklist

- [ ] Add documentation (need help)
- [ ] Complete the TODO's 
- [ ] Implement checks for proxy & tor connection

