### PR TITLE
 💄 Spacing between the names of the search engines in the search results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4066,7 +4066,7 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "websurfx"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/public/static/themes/simple.css
+++ b/public/static/themes/simple.css
@@ -326,6 +326,9 @@ footer {
   font-size: 1.2rem;
   padding: 1rem;
   color: var(--color-five);
+  display: flex;
+  gap: 1rem;
+  justify-content: right;
 }
 
 /* Styles for the 404 page  */


### PR DESCRIPTION
## What does this PR do?

Spacing between the names of the upstream search engines in the search results is fixed.


## Related issues

Closes https://github.com/neon-mmd/websurfx/issues/421
<!--
Closes #234
-->
