### PR TITLE
🐛 Openssl runtime dependencies for `nix flake`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,8 @@
             rustPackages.clippy
             rustc
             yamllint
+            openssl
+            pkg-config
           ];
           RUST_SRC_PATH = rustPlatform.rustLibSrc;
         };


### PR DESCRIPTION
## What does this PR do?
- OpenSSL dependencies are usually readily available for non-Nix distros but not for NixOS users.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->
- Enables devs running NixOS to contribute

<!-- explain the motivation behind your PR -->

## Additional Notes

<!-- additional notes for reviewers -->
- I ran into trouble making this PR because `rusty-hook` CLI is not auto-installed when running `cargo test`. This is only specific to NixOS since global installs are not a thing. I am attempting to make a fix: package `rusty-hook` and include it in the flake.
- Another odd thing is that running `git commit --no-verify` doesn't work and still attempts to run `rusty-hook`. The hack I did is to comment out all hooks in `.git/hooks` that hinders: from `prepare-commit-msg` to `pre-push`. A real hassle. Any ideas why this is the case? 

## Related issues
Closes #448 
<!--
Closes #234
-->
