### PR TITLE
:technologist: Cargo-watch installation via nix dev shell 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
             nodePackages_latest.stylelint
             redis
             rustPackages.clippy
+            cargo-watch
             rustc
             yamllint
             openssl


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->
- Contributors using NixOS won't need to install cargo-watch imperatively via `cargo` since it is already packaged up in `nixpkgs`

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->
- It leverages Nix's declarative nature to install dev dependencies, i.e. `cargo-watch`.

<!-- explain the motivation behind your PR -->

## Related issues
Close #447
<!--
Closes #234
-->
