### PR TITLE
🐛 Explicit Content-Type header for HTTP response

### DIFF
--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -12,14 +12,16 @@ use std::fs::read_to_string;
 /// Handles the route of index page or main page of the `websurfx` meta search engine website.
 #[get("/")]
 pub async fn index(config: web::Data<Config>) -> Result<HttpResponse, Box<dyn std::error::Error>> {
-    Ok(HttpResponse::Ok().body(
-        crate::templates::views::index::index(
-            &config.style.colorscheme,
-            &config.style.theme,
-            &config.style.animation,
-        )
-        .0,
-    ))
+    Ok(HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(
+            crate::templates::views::index::index(
+                &config.style.colorscheme,
+                &config.style.theme,
+                &config.style.animation,
+            )
+            .0,
+        ))
 }
 
 /// Handles the route of any other accessed route/page which is not provided by the
@@ -52,14 +54,16 @@ pub async fn robots_data(_req: HttpRequest) -> Result<HttpResponse, Box<dyn std:
 /// Handles the route of about page of the `websurfx` meta search engine website.
 #[get("/about")]
 pub async fn about(config: web::Data<Config>) -> Result<HttpResponse, Box<dyn std::error::Error>> {
-    Ok(HttpResponse::Ok().body(
-        crate::templates::views::about::about(
-            &config.style.colorscheme,
-            &config.style.theme,
-            &config.style.animation,
-        )
-        .0,
-    ))
+    Ok(HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(
+            crate::templates::views::about::about(
+                &config.style.colorscheme,
+                &config.style.theme,
+                &config.style.animation,
+            )
+            .0,
+        ))
 }
 
 /// Handles the route of settings page of the `websurfx` meta search engine website.
@@ -67,16 +71,18 @@ pub async fn about(config: web::Data<Config>) -> Result<HttpResponse, Box<dyn st
 pub async fn settings(
     config: web::Data<Config>,
 ) -> Result<HttpResponse, Box<dyn std::error::Error>> {
-    Ok(HttpResponse::Ok().body(
-        crate::templates::views::settings::settings(
-            &config.style.colorscheme,
-            &config.style.theme,
-            &config.style.animation,
-            &config
-                .upstream_search_engines
-                .keys()
-                .collect::<Vec<&String>>(),
-        )?
-        .0,
-    ))
+    Ok(HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(
+            crate::templates::views::settings::settings(
+                &config.style.colorscheme,
+                &config.style.theme,
+                &config.style.animation,
+                &config
+                    .upstream_search_engines
+                    .keys()
+                    .collect::<Vec<&String>>(),
+            )?
+            .0,
+        ))
 }


### PR DESCRIPTION
## What does this PR do?

Add Content-Type header for some routes.

## Why is this change important?

Make website accessible through cloudflare tunnel.

## How to test this PR locally?

1. Download cloudflared, install service, assign a hostname `https://<test-domain>` to `http://localhost:8080`.
2. Open https://<test-domain> in browser. Before this change it will returns a plain txt, now it should returns a normal webpage.

## Author's checklist

It has been tested locally.

## Related issues

Closes #456
