### PR TITLE
🐛 Explicit Content-Type header for the search page response

### DIFF
--- a/src/server/routes/search.rs
+++ b/src/server/routes/search.rs
@@ -68,16 +68,18 @@ pub async fn search(
                 get_results(page + 1)
             );
 
-            Ok(HttpResponse::Ok().body(
-                crate::templates::views::search::search(
-                    &config.style.colorscheme,
-                    &config.style.theme,
-                    &config.style.animation,
-                    query,
-                    &results?,
-                )
-                .0,
-            ))
+            Ok(HttpResponse::Ok()
+                .content_type("text/html; charset=utf-8")
+                .body(
+                    crate::templates::views::search::search(
+                        &config.style.colorscheme,
+                        &config.style.theme,
+                        &config.style.animation,
+                        query,
+                        &results?,
+                    )
+                    .0,
+                ))
         }
         None => Ok(HttpResponse::TemporaryRedirect()
             .insert_header(("location", "/"))


### PR DESCRIPTION
## What does this PR do?

Provide Content-Type header for the `search` page.
I missed a commit.
Sorry for the inconvenience.

## Why is this change important?

This change is important because it provides the content-type header which is important for providing the correct content rendering/handling information to the browser. Also, ny providing this header it mitigates a number of security vulnerabilities like Cross Site Request Forgery (CSRF) and Remote Code Execution (RCE) attacks.

**For more information:**
- https://www.invicti.com/blog/web-security/importance-content-type-header-http-requests/

## Related issues

issue https://github.com/neon-mmd/websurfx/issues/456
pr https://github.com/neon-mmd/websurfx/pull/457
