### PR TITLE
:recycle: Start tracking page numbers from 0 instead of 1 in the backend

### DIFF
--- a/src/server/routes/search.rs
+++ b/src/server/routes/search.rs
@@ -59,11 +59,11 @@ pub async fn search(
                 )
             };
 
-            // .max(1) makes sure that the page > 0.
-            let page = params.page.unwrap_or(1).max(1);
+            // .max(1) makes sure that the page >= 0.
+            let page = params.page.unwrap_or(1).max(1) - 1;
 
             let (_, results, _) = join!(
-                get_results(page - 1),
+                get_results(page.saturating_sub(1)),
                 get_results(page),
                 get_results(page + 1)
             );


### PR DESCRIPTION
## What does this PR do?

Modified server::routes::search.rs to subtract one from the page number that's displayed to the user. So if the user sees they're on page 1, the backend will instead treat it as page 0 to be consistent with other search engines and programming lists.

## Why is this change important?

This will help reduce confusion by allowing the different implementations of search engines to be more consistent with one another.

## How to test this PR locally?

Test that the search results appear as expected. Right now the UI will let you go down from page 1 to  page 0.

## Related issues

Potentially closes #459
