### PR TITLE
♻️ Standardize the content-type header by using an enum value over typing it manually 

### DIFF
--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -6,22 +6,20 @@ use crate::{
     config::parser::Config,
     handler::{file_path, FileType},
 };
-use actix_web::{get, web, HttpRequest, HttpResponse};
+use actix_web::{get, http::header::ContentType, web, HttpRequest, HttpResponse};
 use std::fs::read_to_string;
 
 /// Handles the route of index page or main page of the `websurfx` meta search engine website.
 #[get("/")]
 pub async fn index(config: web::Data<Config>) -> Result<HttpResponse, Box<dyn std::error::Error>> {
-    Ok(HttpResponse::Ok()
-        .content_type("text/html; charset=utf-8")
-        .body(
-            crate::templates::views::index::index(
-                &config.style.colorscheme,
-                &config.style.theme,
-                &config.style.animation,
-            )
-            .0,
-        ))
+    Ok(HttpResponse::Ok().content_type(ContentType::html()).body(
+        crate::templates::views::index::index(
+            &config.style.colorscheme,
+            &config.style.theme,
+            &config.style.animation,
+        )
+        .0,
+    ))
 }
 
 /// Handles the route of any other accessed route/page which is not provided by the
@@ -29,16 +27,14 @@ pub async fn index(config: web::Data<Config>) -> Result<HttpResponse, Box<dyn st
 pub async fn not_found(
     config: web::Data<Config>,
 ) -> Result<HttpResponse, Box<dyn std::error::Error>> {
-    Ok(HttpResponse::Ok()
-        .content_type("text/html; charset=utf-8")
-        .body(
-            crate::templates::views::not_found::not_found(
-                &config.style.colorscheme,
-                &config.style.theme,
-                &config.style.animation,
-            )
-            .0,
-        ))
+    Ok(HttpResponse::Ok().content_type(ContentType::html()).body(
+        crate::templates::views::not_found::not_found(
+            &config.style.colorscheme,
+            &config.style.theme,
+            &config.style.animation,
+        )
+        .0,
+    ))
 }
 
 /// Handles the route of robots.txt page of the `websurfx` meta search engine website.
@@ -47,23 +43,21 @@ pub async fn robots_data(_req: HttpRequest) -> Result<HttpResponse, Box<dyn std:
     let page_content: String =
         read_to_string(format!("{}/robots.txt", file_path(FileType::Theme)?))?;
     Ok(HttpResponse::Ok()
-        .content_type("text/plain; charset=ascii")
+        .content_type(ContentType::plaintext())
         .body(page_content))
 }
 
 /// Handles the route of about page of the `websurfx` meta search engine website.
 #[get("/about")]
 pub async fn about(config: web::Data<Config>) -> Result<HttpResponse, Box<dyn std::error::Error>> {
-    Ok(HttpResponse::Ok()
-        .content_type("text/html; charset=utf-8")
-        .body(
-            crate::templates::views::about::about(
-                &config.style.colorscheme,
-                &config.style.theme,
-                &config.style.animation,
-            )
-            .0,
-        ))
+    Ok(HttpResponse::Ok().content_type(ContentType::html()).body(
+        crate::templates::views::about::about(
+            &config.style.colorscheme,
+            &config.style.theme,
+            &config.style.animation,
+        )
+        .0,
+    ))
 }
 
 /// Handles the route of settings page of the `websurfx` meta search engine website.
@@ -71,16 +65,16 @@ pub async fn about(config: web::Data<Config>) -> Result<HttpResponse, Box<dyn st
 pub async fn settings(
     config: web::Data<Config>,
 ) -> Result<HttpResponse, Box<dyn std::error::Error>> {
-    Ok(HttpResponse::Ok()
-        .content_type("text/html; charset=utf-8")
-        .body(
-            crate::templates::views::settings::settings(
-                config.safe_search,
-                &config.style.colorscheme,
-                &config.style.theme,
-                &config.style.animation,
-                &config.upstream_search_engines,
-            )?
-            .0,
-        ))
+    Ok(HttpResponse::Ok().content_type(ContentType::html()).body(
+        crate::templates::views::settings::settings(
+            &config.style.colorscheme,
+            &config.style.theme,
+            &config.style.animation,
+            &config
+                .upstream_search_engines
+                .keys()
+                .collect::<Vec<&String>>(),
+        )?
+        .0,
+    ))
 }

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -67,13 +67,11 @@ pub async fn settings(
 ) -> Result<HttpResponse, Box<dyn std::error::Error>> {
     Ok(HttpResponse::Ok().content_type(ContentType::html()).body(
         crate::templates::views::settings::settings(
+            config.safe_search,
             &config.style.colorscheme,
             &config.style.theme,
             &config.style.animation,
-            &config
-                .upstream_search_engines
-                .keys()
-                .collect::<Vec<&String>>(),
+            &config.upstream_search_engines,
         )?
         .0,
     ))

--- a/src/server/routes/search.rs
+++ b/src/server/routes/search.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     results::aggregator::aggregate,
 };
-use actix_web::{get, web, HttpRequest, HttpResponse};
+use actix_web::{get, http::header::ContentType, web, HttpRequest, HttpResponse};
 use regex::Regex;
 use std::{
     fs::File,
@@ -68,18 +68,16 @@ pub async fn search(
                 get_results(page + 1)
             );
 
-            Ok(HttpResponse::Ok()
-                .content_type("text/html; charset=utf-8")
-                .body(
-                    crate::templates::views::search::search(
-                        &config.style.colorscheme,
-                        &config.style.theme,
-                        &config.style.animation,
-                        query,
-                        &results?,
-                    )
-                    .0,
-                ))
+            Ok(HttpResponse::Ok().content_type(ContentType::html()).body(
+                crate::templates::views::search::search(
+                    &config.style.colorscheme,
+                    &config.style.theme,
+                    &config.style.animation,
+                    query,
+                    &results?,
+                )
+                .0,
+            ))
         }
         None => Ok(HttpResponse::TemporaryRedirect()
             .insert_header(("location", "/"))


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

Refactoring the code to use the `actix-web` crate provided content-type headers for this in the router.rs file located in the src/server. Also, in the search.rs file

## Why is this change important?

This change is essential as it standardizes content-type headers instead of typing them manually, which can be prone to errors like unintentional addition of white spaces, etc.

## Author's checklist

<!-- additional notes for reviewers -->

- [ ] Settings function has another input parameters (safe_search_level and engine_names: &HashMap<String, bool>). So code in issue will not compile without changes in settings function. 

## Related issues

Closes #466 
