### PR TITLE
⚡️ Improve page load by optimizing the caching code 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,7 +4146,7 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "websurfx"
-version = "1.9.0"
+version = "1.9.4"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.9.0"
+version = "1.9.4"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/src/cache/cacher.rs
+++ b/src/cache/cacher.rs
@@ -337,7 +337,11 @@ impl Cacher for RedisCache {
         urls: &[String],
     ) -> Result<(), Report<CacheError>> {
         use base64::Engine;
-        let mut bytes = Vec::with_capacity(3);
+
+        // size of search_results is expected to be equal to size of urls -> key/value pairs  for cache;
+        let search_results_len = search_results.len();
+
+        let mut bytes = Vec::with_capacity(search_results_len);
 
         for result in search_results {
             let processed = self.pre_process_search_results(result)?;
@@ -348,7 +352,7 @@ impl Cacher for RedisCache {
             .iter()
             .map(|bytes_vec| base64::engine::general_purpose::STANDARD_NO_PAD.encode(bytes_vec));
 
-        let mut hashed_url_strings = Vec::with_capacity(3);
+        let mut hashed_url_strings = Vec::with_capacity(search_results_len);
 
         for url in urls {
             let hash = self.hash_url(url);

--- a/src/cache/cacher.rs
+++ b/src/cache/cacher.rs
@@ -4,6 +4,7 @@
 use error_stack::Report;
 #[cfg(feature = "memory-cache")]
 use mini_moka::sync::Cache as MokaCache;
+use mini_moka::sync::ConcurrentCacheExt;
 
 #[cfg(feature = "memory-cache")]
 use std::time::Duration;
@@ -61,8 +62,8 @@ pub trait Cacher: Send + Sync {
     /// failure.
     async fn cache_results(
         &mut self,
-        search_results: &SearchResults,
-        url: &str,
+        search_results: &[SearchResults],
+        urls: &[String],
     ) -> Result<(), Report<CacheError>>;
 
     /// A helper function which computes the hash of the url and formats and returns it as string.
@@ -332,14 +333,29 @@ impl Cacher for RedisCache {
 
     async fn cache_results(
         &mut self,
-        search_results: &SearchResults,
-        url: &str,
+        search_results: &[SearchResults],
+        urls: &[String],
     ) -> Result<(), Report<CacheError>> {
         use base64::Engine;
-        let bytes = self.pre_process_search_results(search_results)?;
-        let base64_string = base64::engine::general_purpose::STANDARD_NO_PAD.encode(bytes);
-        let hashed_url_string = self.hash_url(url);
-        self.cache_json(&base64_string, &hashed_url_string).await
+        let mut bytes = Vec::with_capacity(3);
+
+        for result in search_results {
+            let processed = self.pre_process_search_results(result)?;
+            bytes.push(processed);
+        }
+
+        let base64_strings = bytes
+            .iter()
+            .map(|bytes_vec| base64::engine::general_purpose::STANDARD_NO_PAD.encode(bytes_vec));
+
+        let mut hashed_url_strings = Vec::with_capacity(3);
+
+        for url in urls {
+            let hash = self.hash_url(url);
+            hashed_url_strings.push(hash);
+        }
+        self.cache_json(base64_strings, hashed_url_strings.into_iter())
+            .await
     }
 }
 /// TryInto implementation for SearchResults from Vec<u8>
@@ -391,12 +407,16 @@ impl Cacher for InMemoryCache {
 
     async fn cache_results(
         &mut self,
-        search_results: &SearchResults,
-        url: &str,
+        search_results: &[SearchResults],
+        urls: &[String],
     ) -> Result<(), Report<CacheError>> {
-        let hashed_url_string = self.hash_url(url);
-        let bytes = self.pre_process_search_results(search_results)?;
-        self.cache.insert(hashed_url_string, bytes);
+        for (url, search_result) in urls.iter().zip(search_results.iter()) {
+            let hashed_url_string = self.hash_url(url);
+            let bytes = self.pre_process_search_results(search_result)?;
+            self.cache.insert(hashed_url_string, bytes);
+        }
+
+        self.cache.sync();
         Ok(())
     }
 }
@@ -434,11 +454,13 @@ impl Cacher for HybridCache {
 
     async fn cache_results(
         &mut self,
-        search_results: &SearchResults,
-        url: &str,
+        search_results: &[SearchResults],
+        urls: &[String],
     ) -> Result<(), Report<CacheError>> {
-        self.redis_cache.cache_results(search_results, url).await?;
-        self.memory_cache.cache_results(search_results, url).await?;
+        self.redis_cache.cache_results(search_results, urls).await?;
+        self.memory_cache
+            .cache_results(search_results, urls)
+            .await?;
 
         Ok(())
     }
@@ -460,8 +482,8 @@ impl Cacher for DisabledCache {
 
     async fn cache_results(
         &mut self,
-        _search_results: &SearchResults,
-        _url: &str,
+        _search_results: &[SearchResults],
+        _urls: &[String],
     ) -> Result<(), Report<CacheError>> {
         Ok(())
     }
@@ -519,11 +541,11 @@ impl SharedCache {
     /// on a failure.
     pub async fn cache_results(
         &self,
-        search_results: &SearchResults,
-        url: &str,
+        search_results: &[SearchResults],
+        urls: &[String],
     ) -> Result<(), Report<CacheError>> {
         let mut mut_cache = self.cache.lock().await;
-        mut_cache.cache_results(search_results, url).await
+        mut_cache.cache_results(search_results, urls).await
     }
 }
 

--- a/src/cache/redis_cacher.rs
+++ b/src/cache/redis_cacher.rs
@@ -118,14 +118,18 @@ impl RedisCache {
     /// on a failure.
     pub async fn cache_json(
         &mut self,
-        json_results: &str,
-        key: &str,
+        json_results: impl Iterator<Item = String>,
+        keys: impl Iterator<Item = String>,
     ) -> Result<(), Report<CacheError>> {
         self.current_connection = Default::default();
+        let mut pipeline = redis::Pipeline::with_capacity(3);
 
-        let mut result: Result<(), RedisError> = self.connection_pool
-            [self.current_connection as usize]
-            .set_ex(key, json_results, self.cache_ttl.into())
+        for (key, json_result) in keys.zip(json_results) {
+            pipeline.set_ex(key, json_result, self.cache_ttl.into());
+        }
+
+        let mut result: Result<(), RedisError> = pipeline
+            .query_async(&mut self.connection_pool[self.current_connection as usize])
             .await;
 
         // Code to check whether the current connection being used is dropped with connection error
@@ -145,8 +149,10 @@ impl RedisCache {
                                 CacheError::PoolExhaustionWithConnectionDropError,
                             ));
                         }
-                        result = self.connection_pool[self.current_connection as usize]
-                            .set_ex(key, json_results, 60)
+                        result = pipeline
+                            .query_async(
+                                &mut self.connection_pool[self.current_connection as usize],
+                            )
                             .await;
                         continue;
                     }


### PR DESCRIPTION
## What does this PR do?
It reduces the time it takes for the search results to appear on the search page by caching the next, current and previous page search results simultaneously using Redis pipelining and mini-mocha sync methods. And deferring the caching of the caching of the search results once all the search results have been aggregated from the upstream search engines in the search function in the src/server/routes/search.rs file under the codebase by using a non-blocking concurrent/parallel tokio::spawn thread.

## Why is this change important?

 Caching results simultaneously and using a separate non-blocking thread will significantly reduce the time it takes to load the search results to the user. Thus improving user experience and improving the search engine speed.

The idea is to cache results for the next, current and previous pages simultaneously, which can help reduce the time it takes to cache the results from the three pages. Also, caching the search results only when the search results from all three pages have been completely fetched and aggregated. Once the results are fetched and aggregated, this will spawn a new parallel and concurrent thread using something like tokio::spawn. The search results from all three pages would be passed to it and cached parallelly and concurrently using tokio::spawn.

## How to test this PR locally?

It can be tested by installing and running Websurfx as mentioned in the docs and on the readme and by launching the browser and thoroughly testing.
Run the app with any of the cache_stores enabled via feature flags (redis-cache & hybrid ), and use a Redis-client (either cli or a GUI like redisInsight and others). If you inspect Redis, you find that on each search, two more search_results are stored.  Also in the browser, the previous and next search results are loaded faster. 

## Author's checklist
- [x]  Spawn separate tokio tasks to cache the results (src/server/routes/search).
- [x] Use redis-pipeline to set multiple fields concurrently.
- [x]  Change the cacher trait and all cache implementations to support caching multiple values.
- [x] Bump up version to `v1.9.4`

## Related issues

Closes #444 

