### PR TITLE
👷 GitHub action to automate release based on semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: auto commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          branch: feature-123
+          branch: update-from-${{ github.sha }}
       # create PR using GitHub CLI
       - name: create PR with update info
         id: create-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,10 @@ jobs:
         run: |
           appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | sed 's/[v]//')
           sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - name: auto commit
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: feature-123
       # create PR using GitHub CLI
       - name: create PR with update info
         id: create-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         id: merge-pr
         run: gh pr merge --admin --merge --subject 'Merge update info' --delete-branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_RIGHTS_TOKEN }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,21 +29,27 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: rolling
+      - name: create branch 
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: update-from-${{ github.sha }}
       - name: update cargo.toml
         run: |
           appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | sed 's/[v]//')
           sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
       - uses: stefanzweifel/git-auto-commit-action@v5
       # create PR using GitHub CLI
-      - name: create PR with release info
+      - name: create PR with update info
         id: create-pr
-        run: gh pr create --base main --head release-from-${{ github.sha }} --title 'Merge new release into main' --body 'Created by Github action'
+        run: gh pr create --base rolling --head update-from-${{ github.sha }} --title 'Merge new update into rolling' --body 'Created by Github action'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # merge PR using GitHub CLI
-      - name: merge PR with release info
+      - name: merge PR with update info
         id: merge-pr
-        run: gh pr merge --admin --merge --subject 'Merge release info' --delete-branch
+        run: gh pr merge --admin --merge --subject 'Merge update info' --delete-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+  repository-projects: write
 
 concurrency: production
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,7 @@ jobs:
         run: |
           appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
-      - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
-      - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
       - name: regenerate cargo.lock
         run: cargo generate-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,12 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
       # create PR using GitHub CLI
       - name: create PR with release info
-        if: steps.changelog.outputs.skipped == 'false'
         id: create-pr
         run: gh pr create --base main --head release-from-${{ github.sha }} --title 'Merge new release into main' --body 'Created by Github action'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # merge PR using GitHub CLI
       - name: merge PR with release info
-        if: steps.changelog.outputs.skipped == 'false'
         id: merge-pr
         run: gh pr merge --admin --merge --subject 'Merge release info' --delete-branch
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency: production
 jobs:
   build:
     name: bump tag version and release  
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -42,6 +42,7 @@ jobs:
       - name: auto commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
+          commit_message: "[skip ci] Automated Change"
           branch: update-from-${{ github.sha }}
       # create PR using GitHub CLI
       - name: create PR with update info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,26 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: rolling
-      - name: get-app-version
-        id: package-version
-        run: |
-          LF_VERSION=$(cat package.json | jq -r '.version')
-          echo "current-version=$LF_VERSION" >> "$GITHUB_OUTPUT"
       - name: update cargo.toml
         run: |
           appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | sed 's/[v]//')
           sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
       - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          branch: rolling
+      # create PR using GitHub CLI
+      - name: create PR with release info
+        if: steps.changelog.outputs.skipped == 'false'
+        id: create-pr
+        run: gh pr create --base main --head release-from-${{ github.sha }} --title 'Merge new release into main' --body 'Created by Github action'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # merge PR using GitHub CLI
+      - name: merge PR with release info
+        if: steps.changelog.outputs.skipped == 'false'
+        id: merge-pr
+        run: gh pr merge --admin --merge --subject 'Merge release info' --delete-branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Bump release version
+on:
+  pull_request:
+    branches: [rolling]
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+concurrency: production
+
+jobs:
+  build:
+    name: Create Release  
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Taking the Latest Release Tag number
+        id: releaseVersion
+        run: |
+              repo="${{ github.repository }}"
+              release_json=$(curl -s "https://api.github.com/repos/$repo/releases")
+              
+              if [ "$(echo "$release_json" | jq '. | length')" -eq 0 ]; then
+                Release_tag="0.1.0"
+                echo "No releases found. Setting default version to $Release_tag"
+              else
+                Release_tag=$(echo "$release_json" | jq -r '.[0].tag_name')
+                echo "Latest Tag is : $Release_tag"
+              fi
+              
+              echo "::set-output name=Release_tag::$Release_tag"
+                
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: Bumping Major Index
+        id: bump_version_major
+        if: contains(github.event.pull_request.title, 'major')
+        uses: christian-draeger/increment-semantic-version@1.1.0
+        with:
+          current-version: ${{ steps.releaseVersion.outputs.Release_tag }}
+          version-fragment: 'major'
+                    
+      - name: Bumping Minor Index
+        id: bump_version_minor
+        if: contains(github.event.pull_request.title, 'feat') 
+
+        uses: christian-draeger/increment-semantic-version@1.1.0
+        with:
+          current-version: ${{ steps.releaseVersion.outputs.Release_tag }}
+          version-fragment: 'feature'
+          
+      - name: Bumping Patch Index 
+        id: bump_version_patch
+        if: |
+            ${{ contains(github.event.pull_request.title, 'patch') ||
+            contains(github.event.pull_request.title, 'build') ||
+            contains(github.event.pull_request.title, 'chore') ||
+            contains(github.event.pull_request.title, 'ci') ||
+            contains(github.event.pull_request.title, 'docs') ||
+            contains(github.event.pull_request.title, 'style') ||
+            contains(github.event.pull_request.title, 'refactor') ||
+            contains(github.event.pull_request.title, 'perf') ||
+            contains(github.event.pull_request.title, 'test') }}
+        uses: christian-draeger/increment-semantic-version@1.1.0
+        with:
+          current-version: ${{ steps.releaseVersion.outputs.Release_tag }}
+          version-fragment: 'bug'
+          
+      - name: Create release version for bump_version_major
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          create_release() {
+            curl \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/${repo}/releases \
+              -d '{"tag_name":"'"${1}"'","target_commitish":"'"${branch}"'","name":"'"${1}"'","body":"","draft":false,"prerelease":false,"generate_release_notes":true}'
+          }
+
+          repo=${{ github.repository }}
+          branch=${{ github.head_ref }}
+          
+          create_release "${{ steps.bump_version_major.outputs.next-version }}"
+          create_release "${{ steps.bump_version_minor.outputs.next-version }}"
+          create_release "${{ steps.bump_version_patch.outputs.next-version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
           ref: ${{ github.sha }} ## this seems to be required due to https://github.com/anothrNick/github-tag-action/issues/266
           fetch-depth: 0
       - name: Bump version and push tag
+        id: version-bump
         uses: hennejg/github-tag-action@v4.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           echo "current-version=$LF_VERSION" >> "$GITHUB_OUTPUT"
       - name: update cargo.toml
         run: |
-          appversion=$(${{ steps.version-bump.outputs.new_tag }} | sed 's/[v]//')
+          appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | sed 's/[v]//')
           sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,25 @@ jobs:
         id: releaseVersion
         run: |
               repo="${{ github.repository }}"
-              release_json=$(curl -s "https://api.github.com/repos/$repo/releases")
+              latest_release=$(curl -s "https://api.github.com/repos/$repo/releases" | jq -r '.[0].name' )
+              latest_tag=$(curl -s "https://api.github.com/repos/$repo/tags" | jq -r '.[0].tag_name')
+
               
-              if [ "$(echo "$release_json" | jq '. | length')" -eq 0 ]; then
-                Release_tag="0.1.0"
-                echo "No releases found. Setting default version to $Release_tag"
+              if [ -z "$latest_release" ] && [ -z "$latest_tag" ]; then
+                echo "No releases or tags found. Setting default version to 0.1.0"
+                Release_tag="v0.1.0"
+              elif [ -z "$latest_release" ]; then
+                echo "No releases found. Using latest tag version."
+                Release_tag=$latest_release
+              elif [ -z "$latest_tag" ]; then
+                echo "No tags found. Using latest release version."
+                Release_tag=$latest_release
+              elif [[ "$latest_release" > "$latest_tag" ]]; then
+                echo "Latest release is newer. Using release version."
+                Release_tag=$latest_tag
               else
-                Release_tag=$(echo "$release_json" | jq -r '.[0].tag_name')
-                echo "Latest Tag is : $Release_tag"
+                echo "Latest tag is newer. Using tag version."
+                Release_tag=$latest_tag
               fi
               
               echo "::set-output name=Release_tag::$Release_tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           RELEASE_BRANCHES: rolling
           DEFAULT_BRANCH: rolling
           pre_release: false
+          PRERELEASE_SUFFIX: ''
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,14 @@ jobs:
         uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE_SUFFIX: 
+          RELEASE_BRANCHES: rolling,stable
         with:
           tag_name: ${{ steps.version-bump.outputs.new_tag }}
           release_name: ${{ steps.version-bump.outputs.new_tag }}
           body: |
             ${{ steps.Changelog.outputs.changelog }}
+          
           draft: false
           prerelease: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Bump version and push tag
         uses: hennejg/github-tag-action@v4.1.jh1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRERELEASE_SUFFIX: 
+          PRERELEASE: false
           RELEASE_BRANCHES: rolling,stable
         with:
           tag_name: ${{ steps.version-bump.outputs.new_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,10 @@ jobs:
         with:
           ref: ${{ github.sha }} ## this seems to be required due to https://github.com/anothrNick/github-tag-action/issues/266
           fetch-depth: 0
-      - name:  'Automated Version Bump'
-        id: version-bump
-        uses: anothrNick/github-tag-action@1.36.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
-          DEFAULT_BUMP: patch
-          PRERELEASE: false
-          RELEASE_BRANCHES: rolling
-          DEFAULT_BRANCH: rolling
-          pre_release: false
-          PRERELEASE_SUFFIX: ''
+      - name: Bump version and push tag
+        uses: hennejg/github-tag-action@v4.1.jh1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.sha }} ## this seems to be required due to https://github.com/anothrNick/github-tag-action/issues/266
+          ref: ${{ github.sha }}
           fetch-depth: 0
       - name: Bump version and push tag
         id: version-bump
@@ -27,11 +27,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: rolling
-      - name: Changelog
-        uses: scottbrenner/generate-changelog-action@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,25 +26,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
+          PRERELEASE: false
+          DEFAULT_BRANCH: rolling
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog
         env:
           REPO: ${{ github.repository }}
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRERELEASE: false
-          RELEASE_BRANCHES: rolling,stable
-          PRERELEASE_SUFFIX: ''
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
+          name: ${{ steps.version-bump.outputs.new_tag }}
           tag_name: ${{ steps.version-bump.outputs.new_tag }}
-          release_name: ${{ steps.version-bump.outputs.new_tag }}
-          body: |
-            ${{ steps.Changelog.outputs.changelog }}
-          
-          draft: false
           prerelease: false
+        env:
+          GITHUB_REPOSITORY: my_gh_org/my_gh_repo
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           create_release() {
           local version="${1}"
           if [ -n "${version}" ]; then
-            version="V${version}"
+            version="v${version}"
           fi
           curl \
             -X POST \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,15 @@ concurrency: production
 
 jobs:
   build:
-    name: Create Release  
+    name: bump tag version and release  
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-        
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }} ## this seems to be required due to https://github.com/anothrNick/github-tag-action/issues/266
+          fetch-depth: 0
       - name:  'Automated Version Bump'
         id: version-bump
         uses: anothrNick/github-tag-action@1.36.0
@@ -35,7 +37,6 @@ jobs:
           REPO: ${{ github.repository }}
       - name: Create Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           generate_release_notes: true
@@ -43,5 +44,5 @@ jobs:
           tag_name: ${{ steps.version-bump.outputs.new_tag }}
           prerelease: false
         env:
-          GITHUB_REPOSITORY: my_gh_org/my_gh_repo
+          GITHUB_REPOSITORY: ${{ github.repository }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
                 Release_tag=$latest_release
               elif [[ "$latest_release" > "$latest_tag" ]]; then
                 echo "Latest release is newer. Using release version."
-                Release_tag=$latest_tag
+                Release_tag=$latest_release
               else
                 echo "Latest tag is newer. Using tag version."
                 Release_tag=$latest_tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
                 Release_tag="v0.1.0"
               elif [ -z "$latest_release" ]; then
                 echo "No releases found. Using latest tag version."
-                Release_tag=$latest_release
+                Release_tag=$latest_tag
               elif [ -z "$latest_tag" ]; then
                 echo "No tags found. Using latest release version."
                 Release_tag=$latest_release
@@ -85,17 +85,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           create_release() {
-            curl \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              https://api.github.com/repos/${repo}/releases \
-              -d '{"tag_name":"'"${1}"'","target_commitish":"'"${branch}"'","name":"'"${1}"'","body":"","draft":false,"prerelease":false,"generate_release_notes":true}'
+          local version="${1}"
+          if [ -n "${version}" ]; then
+            version="V${version}"
+          fi
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${repo}/releases \
+            -d '{"tag_name":"'"${version}"'","target_commitish":"'"${branch}"'","name":"'"${version}"'","body":"","draft":false,"prerelease":false,"generate_release_notes":true}'
           }
 
           repo=${{ github.repository }}
           branch=${{ github.head_ref }}
-          
-          create_release "${{ steps.bump_version_major.outputs.next-version }}"
-          create_release "${{ steps.bump_version_minor.outputs.next-version }}"
-          create_release "${{ steps.bump_version_patch.outputs.next-version }}"
+
+          # Check if steps are defined before calling create_release so we don't do unnecessary steps
+          if [ -n "${{ steps.bump_version_major.outputs.next-version }}" ]; then
+            create_release "${{ steps.bump_version_major.outputs.next-version }}"
+          fi
+
+          if [ -n "${{ steps.bump_version_minor.outputs.next-version }}" ]; then
+            create_release "${{ steps.bump_version_minor.outputs.next-version }}"
+          fi
+
+          if [ -n "${{ steps.bump_version_patch.outputs.next-version }}" ]; then
+            create_release "${{ steps.bump_version_patch.outputs.next-version }}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,4 @@ jobs:
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,11 @@ jobs:
         
       - name:  'Automated Version Bump'
         id: version-bump
-        uses:  'phips28/gh-action-bump-version@master'
+        uses: anothrNick/github-tag-action@1.36.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          major-wording:  'MAJOR,major-change'
-          minor-wording:  'feat,'
-          patch-wording:  'patch,fix,build,chore,ci,docs,style,refactor,perf,test'     # Providing patch-wording will override commits
-          tag-prefix:  'v'
-          default: patch
+          WITH_V: true
+          DEFAULT_BUMP: patch
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog
@@ -41,8 +37,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.version-bump.outputs.newTag }}
-          release_name: ${{ steps.version-bump.outputs.newTag }}
+          tag_name: ${{ steps.version-bump.outputs.new_tag }}
+          release_name: ${{ steps.version-bump.outputs.new_tag }}
           body: |
             ${{ steps.Changelog.outputs.changelog }}
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           WITH_V: true
           DEFAULT_BUMP: patch
           PRERELEASE: false
-          DEFAULT_BRANCH: rolling
+          RELEASE_BRANCHES: rolling
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | sed 's/[v]//')
           sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
+      - uses: stefanzweifel/git-auto-commit-action@v5
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: rolling
-      - name: Changelog
-        uses: scottbrenner/generate-changelog-action@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -42,5 +37,3 @@ jobs:
           prerelease: false
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,15 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: rolling
+      - name: get-app-version
+        id: package-version
+        run: |
+          LF_VERSION=$(cat package.json | jq -r '.version')
+          echo "current-version=$LF_VERSION" >> "$GITHUB_OUTPUT"
+      - name: update cargo.toml
+        run: |
+          appversion=$(${{ steps.version-bump.outputs.new_tag }} | sed 's/[v]//')
+          sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           DEFAULT_BUMP: patch
           PRERELEASE: false
           RELEASE_BRANCHES: rolling
+          DEFAULT_BRANCH: rolling
+          pre_release: false
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -37,12 +37,18 @@ jobs:
           branch: update-from-${{ github.sha }}
       - name: update cargo.toml
         run: |
-          appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | sed 's/[v]//')
+          appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable --profile minimal
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - name: regenerate cargo.lock
+        run: cargo generate-lockfile
       - name: auto commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "[skip ci] update Cargo.toml to ${{ steps.version-bump.outputs.new_tag }}"
+          commit_message: "[skip ci] updating app version to ${{ steps.version-bump.outputs.new_tag }}"
           branch: update-from-${{ github.sha }}
       # create PR using GitHub CLI
       - name: create PR with update info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
           appversion=$(echo "${{ steps.version-bump.outputs.new_tag }}" | sed 's/[v]//')
           sed -i -e "s/^version = .*/version = \"$appversion\"/" Cargo.toml
       - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: rolling
+          tagging_message: ${{ steps.version-bump.outputs.new_tag }}
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRERELEASE: false
           RELEASE_BRANCHES: rolling,stable
+          PRERELEASE_SUFFIX: ''
         with:
           tag_name: ${{ steps.version-bump.outputs.new_tag }}
           release_name: ${{ steps.version-bump.outputs.new_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: auto commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "[skip ci] Automated Change"
+          commit_message: "[skip ci] update Cargo.toml to ${{ steps.version-bump.outputs.new_tag }}"
           branch: update-from-${{ github.sha }}
       # create PR using GitHub CLI
       - name: create PR with update info
@@ -56,7 +56,6 @@ jobs:
         run: gh pr merge --admin --merge --subject 'Merge update info' --delete-branch
         env:
           GH_TOKEN: ${{ secrets.ADMIN_RIGHTS_TOKEN }}
-
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: hennejg/github-tag-action@v4.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: rolling
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: rolling
-          tagging_message: ${{ steps.version-bump.outputs.new_tag }}
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,99 +16,35 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Taking the Latest Release Tag number
-        id: releaseVersion
-        run: |
-              repo="${{ github.repository }}"
-              latest_release=$(curl -s "https://api.github.com/repos/$repo/releases" | jq -r '.[0].name' )
-              latest_tag=$(curl -s "https://api.github.com/repos/$repo/tags" | jq -r '.[0].tag_name')
-
-              
-              if [ -z "$latest_release" ] && [ -z "$latest_tag" ]; then
-                echo "No releases or tags found. Setting default version to 0.1.0"
-                Release_tag="v0.1.0"
-              elif [ -z "$latest_release" ]; then
-                echo "No releases found. Using latest tag version."
-                Release_tag=$latest_tag
-              elif [ -z "$latest_tag" ]; then
-                echo "No tags found. Using latest release version."
-                Release_tag=$latest_release
-              elif [[ "$latest_release" > "$latest_tag" ]]; then
-                echo "Latest release is newer. Using release version."
-                Release_tag=$latest_release
-              else
-                echo "Latest tag is newer. Using tag version."
-                Release_tag=$latest_tag
-              fi
-              
-              echo "::set-output name=Release_tag::$Release_tag"
-                
       - name: Checkout code
         uses: actions/checkout@v2
         
-      - name: Bumping Major Index
-        id: bump_version_major
-        if: contains(github.event.pull_request.title, 'major')
-        uses: christian-draeger/increment-semantic-version@1.1.0
-        with:
-          current-version: ${{ steps.releaseVersion.outputs.Release_tag }}
-          version-fragment: 'major'
-                    
-      - name: Bumping Minor Index
-        id: bump_version_minor
-        if: contains(github.event.pull_request.title, 'feat') 
-
-        uses: christian-draeger/increment-semantic-version@1.1.0
-        with:
-          current-version: ${{ steps.releaseVersion.outputs.Release_tag }}
-          version-fragment: 'feature'
-          
-      - name: Bumping Patch Index 
-        id: bump_version_patch
-        if: |
-            ${{ contains(github.event.pull_request.title, 'patch') ||
-            contains(github.event.pull_request.title, 'build') ||
-            contains(github.event.pull_request.title, 'chore') ||
-            contains(github.event.pull_request.title, 'ci') ||
-            contains(github.event.pull_request.title, 'docs') ||
-            contains(github.event.pull_request.title, 'style') ||
-            contains(github.event.pull_request.title, 'refactor') ||
-            contains(github.event.pull_request.title, 'perf') ||
-            contains(github.event.pull_request.title, 'test') }}
-        uses: christian-draeger/increment-semantic-version@1.1.0
-        with:
-          current-version: ${{ steps.releaseVersion.outputs.Release_tag }}
-          version-fragment: 'bug'
-          
-      - name: Create release version for bump_version_major
-        env: 
+      - name:  'Automated Version Bump'
+        id: version-bump
+        uses:  'phips28/gh-action-bump-version@master'
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          create_release() {
-          local version="${1}"
-          if [ -n "${version}" ]; then
-            version="v${version}"
-          fi
-          curl \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${repo}/releases \
-            -d '{"tag_name":"'"${version}"'","target_commitish":"'"${branch}"'","name":"'"${version}"'","body":"","draft":false,"prerelease":false,"generate_release_notes":true}'
-          }
+        with:
+          major-wording:  'MAJOR,major-change'
+          minor-wording:  'feat,'
+          patch-wording:  'patch,fix,build,chore,ci,docs,style,refactor,perf,test'     # Providing patch-wording will override commits
+          tag-prefix:  'v'
+          default: patch
+      - name: Changelog
+        uses: scottbrenner/generate-changelog-action@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.version-bump.outputs.newTag }}
+          release_name: ${{ steps.version-bump.outputs.newTag }}
+          body: |
+            ${{ steps.Changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
 
-          repo=${{ github.repository }}
-          branch=${{ github.head_ref }}
-
-          # Check if steps are defined before calling create_release so we don't do unnecessary steps
-          if [ -n "${{ steps.bump_version_major.outputs.next-version }}" ]; then
-            create_release "${{ steps.bump_version_major.outputs.next-version }}"
-          fi
-
-          if [ -n "${{ steps.bump_version_minor.outputs.next-version }}" ]; then
-            create_release "${{ steps.bump_version_minor.outputs.next-version }}"
-          fi
-
-          if [ -n "${{ steps.bump_version_patch.outputs.next-version }}" ]; then
-            create_release "${{ steps.bump_version_patch.outputs.next-version }}"
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.sha }} ## this seems to be required due to https://github.com/anothrNick/github-tag-action/issues/266
           fetch-depth: 0
       - name: Bump version and push tag
-        uses: hennejg/github-tag-action@v4.1.jh1
+        uses: hennejg/github-tag-action@v4.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Changelog

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.9.6"
+version = "2.0.10"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.9.6"
+version = "2.0.7"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "2.0.9"
+version = "1.9.6"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.9.6"
+version = "2.0.9"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.9.6"
+version = "2.0.8"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "2.0.4"
+version = "2.0.6"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.9.4"
+version = "2.0.4"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "2.0.10"
+version = "1.9.4"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "2.0.8"
+version = "1.9.6"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "2.0.7"
+version = "1.9.6"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "2.0.4"
+version = "1.9.6"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"


### PR DESCRIPTION
## What does this PR do?

This PR adds a file to automate bumps in release versions each time a PR is successfully closed and merged on Rolling. However if we want to do the same for Stable we can since it would take a small change to the release.yml file. I tested a major release on rolling then I rebased on this branch. Before I had tested minor and patch bumps as well. Anything not following the [semantic-release format](https://github.com/semantic-release/semantic-release) will increment the patch version by one. 

## Why is this change important?

This change is important due to the fact it closes out issue #400 and it stops everyone from having to manually create a release.

## How to test this PR locally?

Place this file in the same location (.github/workflows/release.yml) then successfully merge a PR into the rolling branch. Once this is done you should see the action successfully runs and in a moment you will see the new tag and release. Please create a Personal Access Token or [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) and assign it these settings below. Not pictured is only setting the token to have control of the websurfx repo (or your fork).
![image](https://github.com/neon-mmd/websurfx/assets/80804614/684dcaf9-c1f9-4e59-8f03-35806959bf16)

Once you are done please copy the token since you will not be able to see it again. Then you must add the PAT as a secret called ADMIN_RIGHTS_TOKEN. Please paste in the token you copied from above here. You may follow these steps https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions?tool=webui#creating-secrets-for-a-repository

Note: I used webui screenshots and notes to be more beginner friendly, but you can do this in the CLI as well.

## Author's checklist

N/A

## Related issues
Closes #400 
<!--
Closes #400 
-->
