### PR TITLE
🐛 `parsed_cet` not found in scope error when building the app with the `no-cache` feature

### DIFF
--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -98,6 +98,7 @@ impl Config {
 
         #[cfg(any(feature = "redis-cache", feature = "memory-cache"))]
         let parsed_cet = globals.get::<_, u16>("cache_expiry_time")?;
+        #[cfg(any(feature = "redis-cache", feature = "memory-cache"))]
         let cache_expiry_time = match parsed_cet {
             0..=59 => {
                 log::error!(


### PR DESCRIPTION
## What does this PR do?
Provided a fix for the `parsed_cet` not found error.
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
This change is important so that the `parsed_cet` code is only included when the app is compiled with any feature other than the no-cache feature.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->


## Related issues
Closes #498
<!--
Closes #234
-->
