### PR TITLE
Add support for building on aarch64

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "linker=x86_64-alpine-linux-musl-gcc", "-C", "default-linker-libraries"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "linker=aarch64-alpine-linux-musl-gcc", "-C", "default-linker-libraries"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 
 FROM chef AS planner
 COPY ./Cargo.toml ./Cargo.lock ./
+COPY .cargo/config ./.cargo/config
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM --platform=$BUILDPLATFORM chef AS builder


### PR DESCRIPTION
## What does this PR do?

Currently building on aarch64 CPU fails with the following error:
```bash
/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/luajit-src-210.5.3+29b0b28/luajit2/src/lj_mcode.c

  = note: /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /tmp/rustcesPkLe/libmlua_sys-1c0e60c0a5d4bc62.rlib(lj_mcode.o): in function `lj_mcode_sync':
          lj_mcode.c:(.text.lj_mcode_sync+0x4): undefined reference to `__clear_cache'
          collect2: error: ld returned 1 exit status
```
This PR fixes that issue.

## Why is this change important?

This change will allow us to run `websurfx` on devices with ARM64 CPU like Raspberry Pi.

## How to test this PR locally?

1. Log in to an ARM64-based machine, such as a Raspberry Pi, a MacBook with Apple silicon, or spin up a virtual machine (VM) with ARM64 on any cloud provider that offers such services.
2. Checkout the branch
3. Build a new container image
    ```bash
    docker build -t websurfx --platform=linux/aarch64 .
    
    [+] Building 262.2s (20/20) FINISHED                                                                                                                          docker:orbstack
     => [internal] load build definition from Dockerfile                                                                                                                     0.0s
     => => transferring dockerfile: 2.44kB                                                                                                                                   0.0s
     => [internal] load .dockerignore                                                                                                                                        0.0s
     => => transferring context: 127B                                                                                                                                        0.0s
     => [internal] load metadata for docker.io/library/rust:1.75.0-alpine3.18                                                                                                0.0s
     => [chef 1/4] FROM docker.io/library/rust:1.75.0-alpine3.18                                                                                                             0.0s
     => [internal] load build context                                                                                                                                        0.0s
     => => transferring context: 4.92kB                                                                                                                                      0.0s
     => CACHED [chef 2/4] RUN apk add --no-cache alpine-sdk musl-dev g++ make libcrypto3 libressl-dev upx perl build-base                                                    0.0s
     => CACHED [chef 3/4] RUN cargo install cargo-chef --locked                                                                                                              0.0s
     => CACHED [chef 4/4] WORKDIR /app                                                                                                                                       0.0s
     => CACHED [planner 1/3] COPY ./Cargo.toml ./Cargo.lock ./                                                                                                               0.0s
     => [planner 2/3] COPY .cargo/config ./.cargo/config                                                                                                                     0.0s
     => [planner 3/3] RUN cargo chef prepare --recipe-path recipe.json                                                                                                       0.2s
     => [builder 1/6] COPY --from=planner /app/recipe.json recipe.json                                                                                                       0.0s
     => [builder 2/6] RUN export ARCH=$(uname -m) &&   if [ "memory" = "memory" ] ; then cargo chef cook --release --target=$ARCH-unknown-linux-musl --recipe-path recipe  120.8s
     => [builder 3/6] COPY ./src ./src                                                                                                                                       0.0s
     => [builder 4/6] COPY ./public ./public                                                                                                                                 0.0s
     => [builder 5/6] RUN export ARCH=$(uname -m) &&   if [ "memory" = "memory" ] ; then cargo build --release --target=$ARCH-unknown-linux-musl ;   else if [ "memory" =  131.3s
     => [builder 6/6] RUN export ARCH=$(uname -m)   && upx --lzma --best /app/target/$ARCH-unknown-linux-musl/release/websurfx   && cp /app/target/$ARCH-unknown-linux-musl  9.5s
     => [stage-3 1/2] COPY --from=builder /app/public/ /opt/websurfx/public/                                                                                                 0.0s
     => [stage-3 2/2] COPY --from=builder /usr/local/bin/websurfx /usr/local/bin/websurfx                                                                                    0.0s
     => exporting to image                                                                                                                                                   0.0s
     => => exporting layers                                                                                                                                                  0.0s
     => => writing image sha256:3afc96a22e907d9fa1b800c5b7e96244e60e4f2ab94e10a813caf1155f774700                                                                             0.0s
     => => naming to docker.io/library/websurfx                                                                                                                              0.0s
    ```
4. Run a container from the image
    ```bash
    docker run -t --platform=linux/aarch64 -v ./websurfx/config.lua:/etc/xdg/websurfx/config.lua websurfx
    [INFO  websurfx::cache::cacher] Initialising in-memory cache
    [INFO  websurfx] started server on port 8080 and IP 127.0.0.1
    [INFO  websurfx] Open http://127.0.0.1:8080/ in your browser
    [INFO  actix_server::builder] starting 10 workers
    [INFO  actix_server::server] Actix runtime found; starting in Actix runtime
    ```

## Author's checklist

[Here](https://github.com/mlua-rs/mlua/issues/267#issuecomment-1644559018) a user explains about the same linking problem and how he has fixed it.  
So, all the credits should go to him.  
I only adjusted the `.cargo/config` for this specific project and tested the solution.  

## Related issues

Closes #505
