### PR TITLE
:sparkles: Config option to configure the https adaptive window size for requests

### DIFF
--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub logging: bool,
     /// It stores the option to whether enable or disable debug mode.
     pub debug: bool,
+    /// It toggles whether to use adaptive TCP windows
+    pub adaptive_window: bool,
     /// It stores all the engine names that were enabled by the user.
     pub upstream_search_engines: HashMap<String, bool>,
     /// It stores the time (secs) which controls the server request timeout.
@@ -68,6 +70,7 @@ impl Config {
 
         let debug: bool = globals.get::<_, bool>("debug")?;
         let logging: bool = globals.get::<_, bool>("logging")?;
+        let adaptive_window: bool = globals.get::<_, bool>("adaptive_window")?;
 
         if !logging_initialized {
             set_logging_level(debug, logging);
@@ -125,6 +128,7 @@ impl Config {
             },
             logging,
             debug,
+            adaptive_window,
             upstream_search_engines: globals
                 .get::<_, HashMap<String, bool>>("upstream_search_engines")?,
             request_timeout: globals.get::<_, u8>("request_timeout")?,

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -30,7 +30,7 @@ pub struct Config {
     pub logging: bool,
     /// It stores the option to whether enable or disable debug mode.
     pub debug: bool,
-    /// It toggles whether to use adaptive TCP windows
+    /// It toggles whether to use adaptive HTTP windows
     pub adaptive_window: bool,
     /// It stores all the engine names that were enabled by the user.
     pub upstream_search_engines: HashMap<String, bool>,

--- a/src/results/aggregator.rs
+++ b/src/results/aggregator.rs
@@ -71,6 +71,7 @@ pub async fn aggregate(
     upstream_search_engines: &[EngineHandler],
     request_timeout: u8,
     safe_search: u8,
+    adaptive_window: bool,
 ) -> Result<SearchResults, Box<dyn std::error::Error>> {
     let client = CLIENT.get_or_init(|| {
         ClientBuilder::new()
@@ -78,6 +79,7 @@ pub async fn aggregate(
             .https_only(true)
             .gzip(true)
             .brotli(true)
+            .http2_adaptive_window(adaptive_window)
             .build()
             .unwrap()
     });

--- a/src/server/routes/search.rs
+++ b/src/server/routes/search.rs
@@ -218,6 +218,7 @@ async fn results(
                             .collect::<Vec<EngineHandler>>(),
                         config.request_timeout,
                         safe_search_level,
+                        config.adaptive_window,
                     )
                     .await?
                 }

--- a/src/server/routes/search.rs
+++ b/src/server/routes/search.rs
@@ -209,16 +209,13 @@ async fn results(
                     aggregate(
                         query,
                         page,
-                        config.aggregator.random_delay,
-                        config.debug,
+                        config,
                         &search_settings
                             .engines
                             .iter()
                             .filter_map(|engine| EngineHandler::new(engine).ok())
                             .collect::<Vec<EngineHandler>>(),
-                        config.request_timeout,
                         safe_search_level,
-                        config.adaptive_window,
                     )
                     .await?
                 }

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -14,8 +14,8 @@ rate_limiter = {
 	number_of_requests = 20, -- The number of request that are allowed within a provided time limit.
 	time_limit = 3, -- The time limit in which the quantity of requests that should be accepted.
 }
--- Set whether the server will use an adaptive/dynamic TCP window size
-adaptive_window = true
+-- Set whether the server will use an adaptive/dynamic HTTPS window size
+https_adaptive_window_size = false
 
 -- ### Search ###
 -- Filter results based on different levels. The levels provided are:

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -14,6 +14,8 @@ rate_limiter = {
 	number_of_requests = 20, -- The number of request that are allowed within a provided time limit.
 	time_limit = 3, -- The time limit in which the quantity of requests that should be accepted.
 }
+-- Set whether the server will use an adaptive/dynamic TCP window size
+adaptive_window = true
 
 -- ### Search ###
 -- Filter results based on different levels. The levels provided are:

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -14,7 +14,7 @@ rate_limiter = {
 	number_of_requests = 20, -- The number of request that are allowed within a provided time limit.
 	time_limit = 3, -- The time limit in which the quantity of requests that should be accepted.
 }
--- Set whether the server will use an adaptive/dynamic HTTPS window size
+-- Set whether the server will use an adaptive/dynamic HTTPS window size, see https://httpwg.org/specs/rfc9113.html#fc-principles
 https_adaptive_window_size = false
 
 -- ### Search ###


### PR DESCRIPTION
## What does this PR do?

Provided a new config option to allow user enable/disable the `https` window size setting for the requests fetching the search results from the upstream search engines.

## Why is this change important?

These change is essential as it allows the user to enable `https` adaptive window sizes option for requests which improves the performance of requests on reliable/stable internet connections which in turn improves user experience ny reducing latency for responses.

## How to test this PR locally?

Check TCP SYN and ACK packets in wireshark for TCP Window Size scaling

## Related issues

Closes #527
