### PR TITLE
✨ Config option to timeout requests for fetching search results from the upstream search engines

### DIFF
--- a/src/results/aggregator.rs
+++ b/src/results/aggregator.rs
@@ -77,6 +77,7 @@ pub async fn aggregate(
     let client = CLIENT.get_or_init(|| {
         ClientBuilder::new()
             .timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
+            .connect_timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
             .https_only(true)
             .gzip(true)
             .brotli(true)


### PR DESCRIPTION
## What does this PR do?
Provides a new HTTP connection setting to the `reqwest::ClientBuilder` to timeout requests for fetching the search results from the upstream search engines.

## Why is this change important?
The reason for including these changes is to timeout connections after a certain user specified period of time. This prevents the connections from hanging on for the response for a long time to return from the upstream search engines which can cause a long a delay for results to show up on the search page. So by working on these change it improves the user experience by not hanging on too long for search results to appear from each upstream engine.

## Related issues
Closes https://github.com/neon-mmd/websurfx/issues/524
<!--
Closes #234
-->
