### PR TITLE
🚸 Further strip away debug symbols to reduce binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,7 +4199,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "websurfx"
-version = "1.11.0"
+version = "1.12.1"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ panic = 'abort'
 incremental = false
 codegen-units = 1
 rpath = false
-strip = "debuginfo"
+strip = "symbols"
 
 [features]
 default = ["memory-cache"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.11.0"
+version = "1.12.1"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"


### PR DESCRIPTION
## What does this PR do?

Replaces the strip option value from debuginfo to symbols to further strip debug symbols during build time to further reduce the binary size.

## Why is this change important?

the following change is to reduce the compiled file size which can allow the user to build the project on low storage devices too. Which helps improve the user experience.

## Related Issues
Closes #520 
