### PR TITLE
✨ Config option to keep `tcp` connection alive for a certain period for subsequent requests

### DIFF
--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -133,7 +133,7 @@ impl Config {
             upstream_search_engines: globals
                 .get::<_, HashMap<String, bool>>("upstream_search_engines")?,
             request_timeout: globals.get::<_, u8>("request_timeout")?,
-            tcp_connection_keepalive: globals.get::<_, u64>("tcp_connection_keepalive")?,
+            tcp_connection_keepalive: globals.get::<_, u8>("tcp_connection_keepalive")?,
             threads,
             rate_limiter: RateLimiter {
                 number_of_requests: rate_limiter["number_of_requests"],

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -42,6 +42,8 @@ pub struct Config {
     /// It stores the level of safe search to be used for restricting content in the
     /// search results.
     pub safe_search: u8,
+    /// It stores the TCP connection keepalive duration in seconds.
+    pub tcp_connection_keepalive: u64,
 }
 
 impl Config {
@@ -131,6 +133,7 @@ impl Config {
             upstream_search_engines: globals
                 .get::<_, HashMap<String, bool>>("upstream_search_engines")?,
             request_timeout: globals.get::<_, u8>("request_timeout")?,
+            tcp_connection_keepalive: globals.get::<_, u64>("tcp_connection_keepalive")?,
             threads,
             rate_limiter: RateLimiter {
                 number_of_requests: rate_limiter["number_of_requests"],

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -43,7 +43,7 @@ pub struct Config {
     /// search results.
     pub safe_search: u8,
     /// It stores the TCP connection keepalive duration in seconds.
-    pub tcp_connection_keepalive: u64,
+    pub tcp_connection_keepalive: u8,
 }
 
 impl Config {

--- a/src/results/aggregator.rs
+++ b/src/results/aggregator.rs
@@ -73,7 +73,6 @@ pub async fn aggregate(
     config: &Config,
     upstream_search_engines: &[EngineHandler],
     safe_search: u8,
-    tcp_connection_keepalive: u8,
 ) -> Result<SearchResults, Box<dyn std::error::Error>> {
     let client = CLIENT.get_or_init(|| {
         ClientBuilder::new()

--- a/src/results/aggregator.rs
+++ b/src/results/aggregator.rs
@@ -73,10 +73,12 @@ pub async fn aggregate(
     config: &Config,
     upstream_search_engines: &[EngineHandler],
     safe_search: u8,
+    tcp_connection_keepalive: u8,
 ) -> Result<SearchResults, Box<dyn std::error::Error>> {
     let client = CLIENT.get_or_init(|| {
         ClientBuilder::new()
             .timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
+            .tcp_keepalive(Duration::from_secs(tcp_connection_keepalive as u64))
             .connect_timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
             .https_only(true)
             .gzip(true)

--- a/src/results/aggregator.rs
+++ b/src/results/aggregator.rs
@@ -77,6 +77,7 @@ pub async fn aggregate(
     let client = CLIENT.get_or_init(|| {
         ClientBuilder::new()
             .timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
+            .connect_timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
             .https_only(true)
             .gzip(true)
             .brotli(true)

--- a/src/results/aggregator.rs
+++ b/src/results/aggregator.rs
@@ -77,7 +77,7 @@ pub async fn aggregate(
     let client = CLIENT.get_or_init(|| {
         ClientBuilder::new()
             .timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
-            .tcp_keepalive(Duration::from_secs(tcp_connection_keepalive as u64))
+            .tcp_keepalive(Duration::from_secs(config.tcp_connection_keepalive as u64))
             .connect_timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
             .https_only(true)
             .gzip(true)

--- a/src/server/routes/search.rs
+++ b/src/server/routes/search.rs
@@ -216,6 +216,7 @@ async fn results(
                             .filter_map(|engine| EngineHandler::new(engine).ok())
                             .collect::<Vec<EngineHandler>>(),
                         safe_search_level,
+                        30,
                     )
                     .await?
                 }

--- a/src/server/routes/search.rs
+++ b/src/server/routes/search.rs
@@ -216,7 +216,6 @@ async fn results(
                             .filter_map(|engine| EngineHandler::new(engine).ok())
                             .collect::<Vec<EngineHandler>>(),
                         safe_search_level,
-                        30,
                     )
                     .await?
                 }

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -10,6 +10,7 @@ production_use = false -- whether to use production mode or not (in other words 
 -- if production_use is set to true
 -- There will be a random delay before sending the request to the search engines, this is to prevent DDoSing the upstream search engines from a large number of simultaneous requests.
 request_timeout = 30 -- timeout for the search requests sent to the upstream search engines to be fetched (value in seconds).
+tcp_connection_keepalive = 30 -- the amount of time the tcp connection should remain alive (or connected to the server). (value in seconds).
 rate_limiter = {
 	number_of_requests = 20, -- The number of request that are allowed within a provided time limit.
 	time_limit = 3, -- The time limit in which the quantity of requests that should be accepted.


### PR DESCRIPTION
## What does this PR do?
It provides a config option under the server section of the config to allow users to keep tcp connections alive for each request for a certain period of time.

## Why is this change essential.
The reason behind including these changes is to allow the user to tweak the TCP connection setting to keep it alive (or connected to the server) for the user specified period of time. This can eliminate the cost of creating new connections by eliminating the need to create a new connection on each new request to the same server for a certain period of time. This can help reduce response latency and improve user experience.

## Related issues
Closes https://github.com/neon-mmd/websurfx/issues/526

<!--
Closes #234
-->
