### PR TITLE
:sparkles:  Rose pine colorscheme variants for the search engine

### DIFF
--- a/public/static/colorschemes/rose-pine-dawn.css
+++ b/public/static/colorschemes/rose-pine-dawn.css
@@ -1,0 +1,12 @@
+:root {
+  --background-color: #faf4ed;
+  --foreground-color: #575279;
+  --logo-color: #d7827e;
+  --color-one: #f2e9e1;
+  --color-two: #907aa9;
+  --color-three: #56949f;
+  --color-four: #ea9d34;
+  --color-five: #d7827e;
+  --color-six: #9893a5;
+  --color-seven: #575279;
+}

--- a/public/static/colorschemes/rose-pine-moon.css
+++ b/public/static/colorschemes/rose-pine-moon.css
@@ -1,0 +1,12 @@
+:root {
+  --background-color: #232136;
+  --foreground-color: #e0def4;
+  --logo-color: #ea9a97;
+  --color-one: #393552;
+  --color-two: #c4a7e7;
+  --color-three: #9ccfd8;
+  --color-four: #f6c177;
+  --color-five: #ea9a97;
+  --color-six: #6e6a86;
+  --color-seven: #e0def4;
+}

--- a/public/static/colorschemes/rose-pine.css
+++ b/public/static/colorschemes/rose-pine.css
@@ -1,0 +1,12 @@
+:root {
+    --background-color: #191724;
+    --foreground-color: #e0def4;
+    --logo-color: #ebbcba;
+    --color-one: #26233a;
+    --color-two: #c4a7e7;
+    --color-three: #9ccfd8;
+    --color-four: #f6c177;
+    --color-five: #eb6f92;
+    --color-six: #6e6a86;
+    --color-seven: #e0def4;
+}

--- a/public/static/themes/simple.css
+++ b/public/static/themes/simple.css
@@ -482,6 +482,7 @@ footer div {
 
 .about-container article .logo-container svg {
   width: clamp(200px, 530px, 815px);
+  color: var(--logo-color);
 }
 
 .about-container article .text-block {


### PR DESCRIPTION
## What does this PR do?

I made 3 color schemes inspired by the original 3 color palettes: Rose Pine, Rose Pine Moon, Rose Pine Dawn. Provides the change to the simple theme to make the logo on the index change with the respect to the color scheme being used. 

## Why is this change important?

I wanted to add more customization to users, especially since these color schemes are some of the most popular with Linux users' dot files. So what better than to have their web surfing match their desktop environment. (In other words: these change will provide much greater user experience when using the search engine.) 
I made this simple change to add continuity between the appearances in the logos.
<!-- explain the motivation behind your PR -->

## How to test this PR locally?
``` shell
git clone https://github.com/phetzy/websurfx.git
cd websurfx
git checkout rolling
cargo build
redis-server --port 8082 &
./target/debug/websurfx
```

## Related issues

Closes #546 
