### PR TITLE
:sparkles: Config option to timeout idle connections within the `reqwest` pool

### DIFF
--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -44,6 +44,8 @@ pub struct Config {
     pub safe_search: u8,
     /// It stores the TCP connection keepalive duration in seconds.
     pub tcp_connection_keepalive: u8,
+    /// It stores the pool idle connection timeout in seconds.
+    pub pool_idle_connection_timeout: u8,
 }
 
 impl Config {
@@ -134,6 +136,7 @@ impl Config {
                 .get::<_, HashMap<String, bool>>("upstream_search_engines")?,
             request_timeout: globals.get::<_, u8>("request_timeout")?,
             tcp_connection_keepalive: globals.get::<_, u8>("tcp_connection_keepalive")?,
+            pool_idle_connection_timeout: globals.get::<_, u8>("pool_idle_connection_timeout")?,
             threads,
             rate_limiter: RateLimiter {
                 number_of_requests: rate_limiter["number_of_requests"],

--- a/src/results/aggregator.rs
+++ b/src/results/aggregator.rs
@@ -78,6 +78,9 @@ pub async fn aggregate(
     let client = CLIENT.get_or_init(|| {
         ClientBuilder::new()
             .timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
+            .pool_idle_timeout(Duration::from_secs(
+                config.pool_idle_connection_timeout as u64,
+            ))
             .tcp_keepalive(Duration::from_secs(config.tcp_connection_keepalive as u64))
             .connect_timeout(Duration::from_secs(config.request_timeout as u64)) // Add timeout to request to avoid DDOSing the server
             .https_only(true)

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -11,6 +11,7 @@ production_use = false -- whether to use production mode or not (in other words 
 -- There will be a random delay before sending the request to the search engines, this is to prevent DDoSing the upstream search engines from a large number of simultaneous requests.
 request_timeout = 30 -- timeout for the search requests sent to the upstream search engines to be fetched (value in seconds).
 tcp_connection_keepalive = 30 -- the amount of time the tcp connection should remain alive (or connected to the server). (value in seconds).
+pool_idle_connection_timeout = 30 -- timeout for the idle connections in the reqwest HTTP connection pool (value in seconds).
 rate_limiter = {
 	number_of_requests = 20, -- The number of request that are allowed within a provided time limit.
 	time_limit = 3, -- The time limit in which the quantity of requests that should be accepted.


### PR DESCRIPTION
## What does this PR do?
Provided the config option under the server section of the config to allow users to timeout idle connections within the reqwest connection pool after a specified period of time to reduce network resource usage.

## Why is this change important?
The reason behind including these changes is to allow the user to tweak the reqwest connection pool timeouts which can help reduce server resources automatically.

## Related issues
Closes https://github.com/neon-mmd/websurfx/issues/525

