### PR TITLE
🩹 Temporary fix for minifying `js` files during build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deranged"
@@ -2123,8 +2123,7 @@ dependencies = [
 [[package]]
 name = "minify-js"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa5546ee8bd66024113e506cabe4230e76635a094c06ea2051b66021dda92e"
+source = "git+https://github.com/RuairidhWilliamson/minify-js?branch=master#8637df12fdb1d86d7586dde8adf4b8a5d39e7067"
 dependencies = [
  "aho-corasick 0.7.20",
  "lazy_static",
@@ -2431,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "parse-js"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2742b5e32dcb5930447ed9f9e401a7dfd883867fc079c4fac44ae8ba3593710e"
+checksum = "26f2abaec4434c4c5ec8bb3abfa112c9779f774b54ef3d9a6321e022cfcced5f"
 dependencies = [
  "aho-corasick 0.7.20",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,12 @@ tempfile = { version = "3.10.1", default-features = false }
 lightningcss = { version = "1.0.0-alpha.55", default-features = false, features = [
     "grid",
 ] }
-minify-js = { version = "0.6.0", default-features = false }
+# Disabled until bug fixing update
+# minify-js = { version = "0.6.0", default-features = false }
+# Temporary fork with fix
+minify-js = { git = "https://github.com/RuairidhWilliamson/minify-js", branch = "master", version = "0.6.0", default-features = false} 
+
+
 
 [profile.dev]
 opt-level = 0


### PR DESCRIPTION
## What does this PR do?

This PR replaces the original `minify-js` crate with its more actively developed and maintained fork. 

## Why is this change important?

This change is important as it provides a temporary fix for the bug caused while minifying the JS files during build until the main crate provides the fix for it.

## How to test this PR locally?

Try running the build script both with and without the change. 

`env PKG_ENV=prod cargo build --release`

## Related issues

Closes #484
