### PR TITLE
🐛 Redis does not invalidate cached search results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
 dependencies = [
- "brotli 5.0.0",
+ "brotli",
  "flate2",
  "futures-core",
  "memchr",
@@ -490,28 +490,7 @@ checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 2.5.1",
-]
-
-[[package]]
-name = "brotli"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 4.0.0",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -872,7 +851,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -891,7 +870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1903,6 +1882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,7 +1992,7 @@ dependencies = [
  "cssparser-color",
  "data-encoding",
  "getrandom",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "parcel_selectors",
  "paste",
@@ -4461,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "websurfx"
-version = "1.17.0"
+version = "1.17.20"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -4481,6 +4469,7 @@ dependencies = [
  "error-stack",
  "fake-useragent",
  "futures 0.3.30",
+ "itertools 0.13.0",
  "keyword_extraction",
  "lightningcss",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.17.0"
+version = "1.17.20"
 edition = "2021"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,14 +82,13 @@ base64 = { version = "0.21.5", default-features = false, features = [
 cfg-if = { version = "1.0.0", default-features = false, optional = true }
 keyword_extraction = { version = "1.4.3", default-features = false, features = [
     "tf_idf",
-
-
 ] }
 
 stop-words = { version = "0.8.0", default-features = false, features = ["iso"] }
 thesaurus = { version = "0.5.2", default-features = false, optional = true, features = [
     "moby",
-] }
+]}
+itertools = {version = "0.13.0", default-features = false}
 
 [dev-dependencies]
 rusty-hook = { version = "^0.11.2", default-features = false }


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue regarding cached search results not invalidating in the redis server by reimplementing the caching code in `search` function and replacing the deprecated `set_ex` function with `set_options` function.

## Why is this change important?

This change is essential because it fixes the issue regarding cache invalidation in redis server which if not dealt properly can cause cached results to never get invalidated and very old results to be provided to the users which can really provide a bad user experience.

## How to test this PR locally?
It can be tested by installing and running Websurfx as mentioned in the `docs` and on the `readme` and by launching the browser and thoroughly testing. By checking one of the cached search results's ttl by requesting the same search query a couple of times. This can be done by running the following commands:

Connect a redis debugging client to the current server:
``` shell
redis-cli -p <port on which the server is running>
```
Fetch one of the cached search result:
``` shell
Key *
```
Checking the cached search result's ttl:
``` shell
tll <paste one of the keys copied from the above command as string>
```

## Author's checklist

- [x] Reimplement the caching code in the `search` function.
- [x] Replace the deprecated `set_ex` function with `set_options` function.
- [x] Bump the app version to `v1.17.20`. 

## Related issues

Closes #592 
