### PR TITLE
:bug: Provide the latest nix flake lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "lastModified": 1725194671,
+        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             haskellPackages.hadolint
             nodejs
             nodePackages_latest.cspell
-            nodePackages_latest.eslint
+            eslint
             nodePackages_latest.markdownlint-cli2
             nodePackages_latest.stylelint
             redis


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

- This updates the `nixpkgs` input in the nix flake in order to bump the `rustc` version from 1.72.0 to 1.80.1 if `websurfx` is packaged via `nix build`
- `nodePackages_latest.eslint` is changed to `eslint` since it's been moved as a top-level package in upstream NixOS/nixpkgs repo

## Why is this change important?

- This enables building `websurfx` in a reproducible manner via nix

## How to test this PR locally?

- Run `nix build .#default`
- Run the build result in `./result/bin/websurfx`



<!-- additional notes for reviewers -->

## Related issues


Closes #580

