### PR TITLE
:recycle: replace deprecated `per_second` with `seconds_per_request` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub fn run(
             .wrap(cors)
             .wrap(Governor::new(
                 &GovernorConfigBuilder::default()
-                    .per_second(config.rate_limiter.time_limit as u64)
+                    .seconds_per_request(config.rate_limiter.time_limit as u64)
                     .burst_size(config.rate_limiter.number_of_requests as u32)
                     .finish()
                     .unwrap(),


### PR DESCRIPTION
## What does this PR do?
Updates rate-limiting middleware to use the new seconds_per_request function and removes usage of the deprecated per_second function.

## Why is this change important?
Using deprecated functions can lead to compatibility issues with future updates of the middleware or framework. By adopting seconds_per_request, you're ensuring that your code remains compatible with upcoming versions, reducing the risk of breaking changes in the future.

## Related issues

Closes #614 