### PR TITLE
:bug: Resolve random delay condition during search for `individual/non-production` self-hosted server

### DIFF
--- a/src/server/routes/search.rs
+++ b/src/server/routes/search.rs
@@ -85,7 +85,7 @@ pub async fn search(
             let next_page = page + 1;
 
             // Add a random delay before making the request.
-            if config.aggregator.random_delay || !config.debug {
+            if config.aggregator.random_delay || config.debug {
                 let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.subsec_nanos() as f32;
                 let delay = ((nanos / 1_0000_0000 as f32).floor() as u64) + 1;
                 tokio::time::sleep(Duration::from_secs(delay)).await;


### PR DESCRIPTION
## What does this PR do?

Provides a fix for the logic to apply the delay when `production_mode` is enabled or when the app is in debug mode.

## Why is the change important?
This change is essential as it fixes the logic for adding delays to only apply delays when in production mode or when in debug mode. 

<!-- MANDATORY -->

## Related issues
Closes https://github.com/neon-mmd/websurfx/issues/615
<!--
Closes #234
-->
