### PR TITLE
🐛 fix(handler): get `$HOME` environment variable at runtime

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -51,7 +51,7 @@ static FILE_PATHS_FOR_DIFF_FILE_TYPES: OnceCell<Vec<(FileType, Vec<String>)>> =
 /// 2. Under project folder ( or codebase in other words) if it is not present
 ///    here then it returns an error as mentioned above.
 pub async fn file_path(file_type: FileType) -> Result<String, Error> {
-    let home = env!("HOME");
+    let home = std::env::var("HOME").unwrap_or(String::new());
 
     let file_path: Vec<String> = FILE_PATHS_FOR_DIFF_FILE_TYPES
         .get_or_init(|| async move {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -51,7 +51,7 @@ static FILE_PATHS_FOR_DIFF_FILE_TYPES: OnceCell<Vec<(FileType, Vec<String>)>> =
 /// 2. Under project folder ( or codebase in other words) if it is not present
 ///    here then it returns an error as mentioned above.
 pub async fn file_path(file_type: FileType) -> Result<String, Error> {
-    let home = std::env::var("HOME").unwrap_or(String::new());
+    let home = std::env::var("HOME").unwrap_or_default();
 
     let file_path: Vec<String> = FILE_PATHS_FOR_DIFF_FILE_TYPES
         .get_or_init(|| async move {


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

The `env!` macro gets an environment variable at **compile time**, emitting a compile time error it's not set.
The `std::env::var` function gets an environment variable at **runtime** and returns a result, which can be handled in the `unwrap_or` function.

This pull request replaces the first with the second approach.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

It makes more sense to use the second variant as one can build the package on another system or environment that has a different HOME variable set.
This is espacially the case with prebuilt binaries or distribution provided packages.
On nix, the home variable would always evaluate to "/homeless-shelter", which isn't right and creates issues: One cannot use configs that are present in `$HOME/.config/websurfx/config.lua`

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->
You can insert something like this under the changed line: `println!("Home: {}", home);`
Running `HOME=/newhome ./target/release/websurfx` after the build would print "HOME: /newhome" in the console instead of the home variable that was set during compilation.



<!--
Closes #234
-->
