### PR TITLE
👷 ops(github_actions): add Linux multi-arch build support to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     branches: [rolling]
     types:
       - closed
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -14,22 +15,31 @@ concurrency: production
 
 jobs:
   build:
-    name: bump tag version and release  
-    if: github.event.pull_request.merged == true 
+    name: bump tag version and release
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.version-bump.outputs.new_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+      - name: Ensure initial tag exists
+        run: |
+          git fetch --tags
+          if ! git tag -l "v*" | grep -q .; then
+            git tag v0.0.0
+            git push origin v0.0.0
+          fi
       - name: Bump version and push tag
         id: version-bump
         uses: hennejg/github-tag-action@v4.4.0
         with:
           github_token: ${{ secrets.ADMIN_RIGHTS_TOKEN }}
           release_branches: rolling
-      - name: create branch 
+      - name: create branch
         uses: peterjgrainger/action-create-branch@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_RIGHTS_TOKEN }}
@@ -60,13 +70,66 @@ jobs:
         run: gh pr merge --admin --merge --subject 'Merge update info' --delete-branch
         env:
           GH_TOKEN: ${{ secrets.ADMIN_RIGHTS_TOKEN }}
+  build-linux:
+    name: build linux binaries
+    needs: build
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_suffix: linux-amd64
+          - os: ubuntu-24.04-arm
+            asset_suffix: linux-arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - name: Install system build tools
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+      - name: Build Linux release binary
+        run: cargo build --release
+      - name: Package Linux artifact
+        run: |
+          mkdir -p dist staging/websurfx staging/websurfx/public
+          cp target/release/websurfx dist/websurfx-${{ matrix.asset_suffix }}
+          chmod +x dist/websurfx-${{ matrix.asset_suffix }}
+          sha256sum dist/websurfx-${{ matrix.asset_suffix }} > dist/websurfx-${{ matrix.asset_suffix }}.sha256
+          cp -r websurfx/* staging/websurfx/
+          cp -r public/* staging/websurfx/public/
+          cp target/release/websurfx staging/websurfx-${{ matrix.asset_suffix }}
+          chmod +x staging/websurfx-${{ matrix.asset_suffix }}
+          tar -czf dist/websurfx-${{ matrix.asset_suffix }}.tar.gz -C staging .
+          sha256sum dist/websurfx-${{ matrix.asset_suffix }}.tar.gz > dist/websurfx-${{ matrix.asset_suffix }}.tar.gz.sha256
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: websurfx-${{ matrix.asset_suffix }}
+          path: dist/*
+          retention-days: 1
+
+  publish-release:
+    name: publish release assets
+    needs: [build, build-linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.ADMIN_RIGHTS_TOKEN }}
           generate_release_notes: true
-          name: ${{ steps.version-bump.outputs.new_tag }}
-          tag_name: ${{ steps.version-bump.outputs.new_tag }}
+          name: ${{ needs.build.outputs.release_tag }}
+          tag_name: ${{ needs.build.outputs.release_tag }}
           prerelease: false
+          files: |
+            websurfx-*/websurfx-*
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
     branches: [rolling]
     types:
       - closed
-  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## What does this PR do?

This PR enhances the release workflow with multi-architecture Linux build support. It adds:
- Separate build job for Linux binaries (amd64 and arm64)
- Matrix strategy to build for both `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64)
- Proper artifact packaging with checksums for both standalone binaries and complete tar.gz archives
- New publish-release job that collects all artifacts and attaches them to the GitHub release
- Initial tag creation check to prevent workflow failures on first run
- `workflow_dispatch` trigger for manual workflow execution

## Why is this change important?

This change enables the project to provide official pre-built binaries for both x86_64 and ARM64 Linux platforms, making it easier for users to deploy websurfx without needing to compile from source. This is especially important for:
- ARM-based servers and Raspberry Pi users
- CI/CD pipelines that need quick deployments
- Users who want to verify binary integrity via SHA256 checksums

## How to test this PR locally?

The workflow can be tested by:
1. Merging a PR into the `rolling` branch, or
2. Manually triggering the workflow via GitHub Actions UI (workflow_dispatch)

The workflow will:
- Bump the version tag
- Build Linux binaries for both architectures
- Create a GitHub release with all artifacts attached

=> final checklist

- Added multi-arch build matrix for Linux (amd64 + arm64)
- implemented proper artifact handling between jobs
- added SHA256 checksums for security verification
- ensured backward compatibility with existing workflow triggers

## Related issues
https://github.com/community-scripts/ProxmoxVE/discussions/10858


=> Screenshots:
---
<img width="395" height="295" alt="image" src="https://github.com/user-attachments/assets/a20cdb33-298e-4d88-9de3-bbd02cdac191" />

---

<img width="383" height="328" alt="image" src="https://github.com/user-attachments/assets/e64e9cd1-735a-4637-acb1-f92d1326c80d" />

---


<img width="1460" height="772" alt="image" src="https://github.com/user-attachments/assets/34ce92cb-11c1-4fd4-9e4a-6b3598c36294" />



in LXC Container:
```shell
root@dawarich:/opt# ls -la
total 25188
drwxr-xr-x  3 1001 1001     4096 Jan 19 09:26 .
drwxr-xr-x 18 root root     4096 Jan 18 11:07 ..
drwxr-xr-x  3 1001 1001     4096 Jan 19 09:31 websurfx
-rwxr-xr-x  1 1001 1001 18188736 Jan 19 09:26 websurfx-linux-amd64
-rw-r--r--  1 root root  7587647 Jan 19 09:26 websurfx-linux-amd64.tar.gz
root@dawarich:/opt# ./websurfx-linux-amd64 
[INFO  websurfx] started server on port 8080 and IP 192.168.3.13
[INFO  websurfx] Open http://192.168.3.13:8080/ in your browser
[INFO  actix_server::builder] starting 10 workers
[INFO  actix_server::server] Actix runtime found; starting in Actix runtime
[INFO  actix_server::server] starting service: "actix-web-service-192.168.3.13:8080", workers: 10, listening on: 192.168.3.13:8080
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensured an initial repository tag exists if none present.
  * Added a workflow output for the release tag and updated release step to use it.
  * Made branch naming for automated branch creation include the trigger SHA.

* **New Features**
  * Added matrix-based Linux builds with packaging and artifact uploads.
  * Added a publish release job that gathers artifacts and attaches them to the release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->