### PR TITLE
:construction_worker: fix(github_action): restrict down access using explicit permissions (#742)

### DIFF
--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -10,6 +10,9 @@ jobs:
   welcome:
     name: Welcome
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/first-interaction@v2
         with:

--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v2
+      - uses: actions/first-interaction@2c1a690e6b60f93eb33eb4a15b9a12afbb4f2f21 # v3.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: |-


### PR DESCRIPTION
closes [https://github.com/neon-mmd/websurfx/security/code-scanning/10]

In general, the fix is to add an explicit `permissions:` block that grants the least privileges necessary to the `GITHUB_TOKEN`, either at the workflow root (applies to all jobs) or within the specific job. For this workflow, the `welcome` job uses `actions/first-interaction@v2` to post a message on the first pull request. That requires the ability to read repository contents/metadata and to write to pull requests (to comment). It doesn’t need broad repository write access.

The single best way to fix this without changing existing behavior is to add a `permissions:` block under the `welcome` job, between `runs-on:` and `steps:`, specifying `contents: read` and `pull-requests: write`. This keeps the permission scope as tight as reasonably possible while still allowing the action to comment on pull requests. No additional imports or external libraries are needed; this is purely a YAML configuration change in `.github/workflows/hello.yml`.

Concretely:
- Edit `.github/workflows/hello.yml`.
- Under `jobs: welcome:`, add:

```yaml
    permissions:
      contents: read
      pull-requests: write
```

- Keep indentation consistent with existing job fields (`runs-on`, `steps`).
- No other files or definitions are required.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration with updated permissions for automated processes.
  * Updated external action reference to a newer version with improved functionality and security fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->