### PR TITLE
:construction_worker: fix(github_action): restrict down access in `rust_format` using explicit permissions (#743)

### DIFF
--- a/.github/workflows/rust_format.yml
+++ b/.github/workflows/rust_format.yml
@@ -1,5 +1,7 @@
 ---
 name: Rust format and clippy checks
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/neon-mmd/websurfx/security/code-scanning/9](https://github.com/neon-mmd/websurfx/security/code-scanning/9)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for the workflow or the specific job. Since this workflow only checks out code and runs Rust formatting, Clippy, and `cargo check`, it only needs read access to repository contents; no writes or other scopes are required.

The best, non-breaking change is to add a `permissions` block at the root level of the workflow (top-level key alongside `name` and `on`). This will apply to all jobs (currently just `check`) that don’t define their own `permissions`. Concretely, in `.github/workflows/rust_format.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` keys (e.g., after line 2). No additional imports, methods, or definitions are needed; this is purely a configuration change to the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance security permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->