### PR TITLE
♻️ refactor(nix): update build workflow with documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,71 +26,53 @@ For the stable version, follow the same steps as above (as mentioned for the `un
 
 ## NixOS
 
-A `flake.nix` has been provided to allow installing `websurfx` easily. It utilizes [nearsk](https://github.com/nix-community/naersk) to automatically generate a derivation based on `Cargo.toml` and `Cargo.lock`.
+A `flake.nix` has been provided to allow installing the git version of `Websurfx` easily.
 
 The Websurfx project provides 2 versions/flavours for the flake `stable` and `rolling/unstable/edge`. The steps for each are covered below in different sections.
 
+The latest released version of `Websurfx` is also being provided together with a NixOS module by Nixpkgs, so you don't need to build or configure the package manually.
+
 ### Rolling/Edge/Unstable
 
-To get started, First, clone the repository, edit the config file which is located in the `websurfx` directory, and then build and run the websurfx server by running the following commands:
+To get started, you can build and run `Websurfx` with the default configuration by running:
 
 ```shell
-git clone https://github.com/neon-mmd/websurfx.git
-cd websurfx
-cp -rf ./websurfx/ ~/.config/
-$ mkdir /opt/websurfx/
-$ cp -rf ./public/ /opt/websurfx/
-nix build .#websurfx
-nix run .#websurfx
+nix run github:neon-mmd/websurfx
 ```
 
-> [!Note]
-> In the above command the dollar sign(**$**) refers to running the command in Privileged mode by using utilities `sudo`, `doas`, `pkgexec`, or any other privileged access methods.
+If you want to change the port or the IP or any other configuration setting, download the default configuration into the `~/.config/websurfx` directory and edit the `config.lua` file.
+Check out the [configuration docs](./configuration.md) for more information.
+
+```shell
+mkdir -p ~/.config/websurfx
+wget https://raw.githubusercontent.com/neon-mmd/websurfx/refs/heads/rolling/websurfx/config.lua -O ~/.config/websurfx/config.lua
+```
 
 Once you have run the above set of commands, open your preferred web browser and navigate to http://127.0.0.1:8080/ to start using Websurfx.
 
-If you want to change the port or the IP or any other configuration setting check out the [configuration docs](./configuration.md).
-
-> Optionally, you may include it in your own flake by adding this repo to its inputs and adding it to `environment.systemPackages` as follows:
->
-> ```nix
-> {
->   description = "My awesome configuration";
->
->   inputs = {
->     websurfx.url = "github:neon-mmd/websurfx";
->   };
->
->   outputs = { nixpkgs, ... }@inputs: {
->     nixosConfigurations = {
->       hostname = nixpkgs.lib.nixosSystem {
->         system = "x86_64-linux";
->         modules = [{
->           environment.systemPackages = [inputs.websurfx.packages.x86_64-linux.websurfx];
->         }];
->       };
->     };
->   };
-> }
-> ```
-
 ### Stable
 
-For the stable version, follow the same steps as above (as mentioned for the `unstable/rolling/edge version`) with an addition of one command which has to be performed after cloning and changing the directory into the repository which makes the building step as follows:
+For the stable version, follow the same steps as above (as mentioned for the `unstable/rolling/edge version`), but refer to the stable branch of the repository instead.
 
 ```shell
-git clone https://github.com/neon-mmd/websurfx.git
-cd websurfx
-git checkout stable
-cp -rf ./websurfx/ ~/.config/
-$ mkdir /opt/websurfx/
-$ cp -rf ./public/ /opt/websurfx/
-nix build .#websurfx
-nix run .#websurfx
+nix run github:neon-mmd/websurfx/stable
 ```
 
-> [!Note]
-> In the above command the dollar sign(**$**) refers to running the command in privileged mode by using utilities `sudo`, `doas`, `pkgexec`, or any other privileged access methods.
+### Nixpkgs
+
+You can add the following configuration options to your `configuration.nix`.
+For more information take a look at the [service options](https://search.nixos.org/options?channel=unstable&show=services.websurfx).
+
+```nix
+services.websurfx = {
+  # Whether to enable the websurfx service
+  enable = true;
+  # Whether to open the used port in the firewall
+  openFirewall = true;
+  # You can specify the configuration settings here
+  settings = { };
+};
+```
 
 ## Other Distros
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,44 +1,30 @@
 {
   "nodes": {
-    "naersk": {
+    "flake-utils": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694081375,
-        "narHash": "sha256-vzJXOUnmkMCm3xw8yfPP5m8kypQ3BhAIRe4RRCWpzy8=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "3f976d822b7b37fc6fb8e6f157c2dd05e7e94e89",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "ref": "master",
-        "repo": "naersk",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
-        "path": "/nix/store/p7iz0r8gs6ppkhj83zjmwyd21k8b7v3y-source",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
-        "type": "path"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1725194671,
-        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
+        "lastModified": 1773840656,
+        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
+        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
         "type": "github"
       },
       "original": {
@@ -50,9 +36,8 @@
     },
     "root": {
       "inputs": {
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
-        "utils": "utils"
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -67,24 +52,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,35 +1,54 @@
 {
-  # Websurfx NixOS flake
+  description = "Websurfx NixOS flake";
+
   inputs = {
-    naersk.url = "github:nix-community/naersk/master";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    utils.url = "github:numtide/flake-utils";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {
-    naersk,
-    nixpkgs,
-    self,
-    utils,
-  }:
-  # We do this for all systems - namely x86_64-linux, aarch64-linux,
-  # x86_64-darwin and aarch64-darwin
-    utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {inherit system;};
-      naersk-lib = pkgs.callPackage naersk {};
-    in rec {
-      # Build via "nix build .#default"
-      packages.default = naersk-lib.buildPackage {
-        # The build dependencies
-        buildInputs = with pkgs; [pkg-config openssl];
-        src = ./.;
-      };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    # We do this for all systems - namely x86_64-linux, aarch64-linux,
+    # x86_64-darwin and aarch64-darwin
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      rec {
+        # Build via "nix build"
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          name = "websurfx";
+          src = ./.;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = [ pkgs.openssl ];
 
-      # Enter devshell with all the tools via "nix develop"
-      # or "nix-shell"
-      devShells.default = with pkgs;
-        mkShell {
-          buildInputs = [
+          # Copys and links files directly into the package
+          postPatch = ''
+            substituteInPlace src/handler.rs \
+              --replace-fail "/etc/xdg" "$out/etc/xdg" \
+              --replace-fail "/opt/websurfx" "$out/opt/websurfx"
+          '';
+          postInstall = ''
+            mkdir -p $out/etc/xdg
+            mkdir -p $out/opt/websurfx
+
+            cp -r websurfx $out/etc/xdg/
+            cp -r public $out/opt/websurfx/
+          '';
+        };
+
+        # Enter devshell with all the tools via "nix develop"
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
             actionlint
             cargo
             docker
@@ -49,15 +68,15 @@
             openssl
             pkg-config
           ];
-          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
           shellHook = ''
             export PATH="$PATH:$HOME/.cargo/bin"
             export NODE_PATH="$NODE_PATH:./node_modules"
           '';
         };
 
-      # Build via "nix build .#websurfx", which is basically just
-      # calls the build function
-      packages.websurfx = packages.default;
-    });
+        # Build via "nix build .#websurfx"
+        packages.websurfx = packages.default;
+      }
+    );
 }


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR fixes the NixOS build workflow, by this I mean the flake.nix file, and it updates the documentation accordingly.
It also adds a Nixpkgs section to the documentation that show, how to enable the NixOS module.

<!-- explain the changes in your PR, algorithms, design, architecture -->

The package gets build using `pkgs.rustPlatform.buildRustPackage` now.
Naersk doesn't work anymore as mlua-sys fails to build as it tries to write into the read-only nix store (I think).
It also patches the source that the required files get added into the package directly, so the user won't need to copy them manually to the necessary paths anymore. This means a simple `nix build` or `nix run` is enough.
The configuration can be changed by downloading and modifying the `config.lua` file in `~/.config/websurfx`.

Credits need to be given to @theobori (sorry for the ping) for the patches from the nixpkgs version.

## Why is this change important?

<!-- MANDATORY -->

The nix build was broken and needed to be fixed.
The documentation got a bit outdated and can be simplified by a lot now.

<!-- explain the motivation behind your PR -->

The last step needed for this issue: https://github.com/neon-mmd/websurfx/issues/581#issuecomment-4103092246

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->
If you have a NixOS system, you can read through the newly added documentation and can check wether all steps are accurate.

<!-- ## Author's checklist -->

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
Closes #581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined NixOS installation: single `nix run` commands for rolling and stable releases and explicit config download/edit steps
  * Added Nixpkgs section for declarative setup via services.websurfx in configuration.nix

* **Chores**
  * Updated Nix packaging and build setup to improve reproducible installs and developer environment consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->