### PR TITLE
✨ feat: `http` caching for the search engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,16 +523,16 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if 1.0.4",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -646,7 +646,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if 1.0.4",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -894,6 +894,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -3082,7 +3091,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4994,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "websurfx"
-version = "1.25.4"
+version = "1.26.0"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.25.4"
+version = "1.26.0"
 edition = "2024"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ use actix_governor::{Governor, GovernorConfigBuilder};
 use actix_web::{
     App, HttpServer,
     dev::Server,
-    http::header,
-    middleware::{Compress, Logger},
+    http::header::{self, CacheControl, CacheDirective},
+    middleware::{Compress, DefaultHeaders, Logger},
     web,
 };
 use handler::{FileType, file_path};
@@ -87,6 +87,11 @@ pub async fn run(listener: TcpListener, config: &'static Config) -> tokio::io::R
                     .finish()
                     .unwrap(),
             ))
+            .wrap(
+                DefaultHeaders::new().add(CacheControl(vec![CacheDirective::MaxAge(
+                    config.http_cache_expiry_time as u32,
+                )])),
+            )
             // Serve images and static files (css and js files).
             .service(
                 fs::Files::new("/static", format!("{}/static", public_folder_path))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -138,9 +138,7 @@ impl Config {
 
         let parsed_hcet = globals.get("http_cache_expiry_time")?;
         let http_cache_expiry_time = if parsed_hcet < 60 {
-            log::error!(
-                "Config Error: The value of `http_cache_expiry_time` must be at least 60"
-            );
+            log::error!("Config Error: The value of `http_cache_expiry_time` must be at least 60");
             log::error!("Falling back to using the value `60` for the option");
             60
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,6 +55,9 @@ pub struct Config {
     pub number_of_https_connections: u8,
     /// It stores the operating system's TLS certificates for https requests.
     pub operating_system_tls_certificates: bool,
+    /// It stores the http-caching's validity time that is how long the http cache will remain
+    /// valid for all the resources that was loaded on the page.
+    pub http_cache_expiry_time: u16,
 }
 
 impl Config {
@@ -133,6 +136,17 @@ impl Config {
                 .ok()
         });
 
+        let parsed_hcet = globals.get("http_cache_expiry_time")?;
+        let http_cache_expiry_time = if parsed_hcet < 60 {
+            log::error!(
+                "Config Error: The value of `http_cache_expiry_time` must be greater than 60"
+            );
+            log::error!("Falling back to using the value `60` for the option");
+            60
+        } else {
+            parsed_hcet
+        };
+
         Ok(Config {
             operating_system_tls_certificates: globals.get("operating_system_tls_certificates")?,
             port: globals.get("port")?,
@@ -165,6 +179,7 @@ impl Config {
             #[cfg(any(feature = "redis-cache", feature = "memory-cache"))]
             cache_expiry_time,
             proxy,
+            http_cache_expiry_time,
         })
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -139,7 +139,7 @@ impl Config {
         let parsed_hcet = globals.get("http_cache_expiry_time")?;
         let http_cache_expiry_time = if parsed_hcet < 60 {
             log::error!(
-                "Config Error: The value of `http_cache_expiry_time` must be greater than 60"
+                "Config Error: The value of `http_cache_expiry_time` must be at least 60"
             );
             log::error!("Falling back to using the value `60` for the option");
             60

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,7 +57,7 @@ pub struct Config {
     pub operating_system_tls_certificates: bool,
     /// It stores the http-caching's validity time that is how long the http cache will remain
     /// valid for all the resources that was loaded on the page.
-    pub http_cache_expiry_time: u16,
+    pub http_cache_expiry_time: u8,
 }
 
 impl Config {

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -67,6 +67,8 @@ animation = "simple-frosted-glow" -- the animation name which should be used wit
 -- ### Caching ###
 redis_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
 cache_expiry_time = 600 -- This option takes the expiry time of the search results (value in seconds and the value should be greater than or equal to 60 seconds).
+http_cache_expiry_time = 600 -- This option takes the expiry time of the http cache (value in seconds and the value should be greater than or equal to 60 seconds).
+
 -- ### Search Engines ###
 upstream_search_engines = {
 	DuckDuckGo = true,

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -67,7 +67,7 @@ animation = "simple-frosted-glow" -- the animation name which should be used wit
 -- ### Caching ###
 redis_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
 cache_expiry_time = 600 -- This option takes the expiry time of the search results (value in seconds and the value should be greater than or equal to 60 seconds).
-http_cache_expiry_time = 600 -- This option takes the expiry time of the http cache (value in seconds and the value should be greater than or equal to 60 seconds).
+http_cache_expiry_time = 60 -- This option takes the expiry time of the http cache (value in seconds and the value should be greater than or equal to 60 seconds).
 
 -- ### Search Engines ###
 upstream_search_engines = {


### PR DESCRIPTION
## What does this PR do?
This PR provides the http caching for the search engine pages.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
These changes are essential as this improves the loading speed of the search engine pages and improve the user experience.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## Author's checklist
- [X] Provide the `http` caching for the search engine.
- [X] Bump the app version to `v1.26.0`

<!-- additional notes for reviewers -->

## Related issues

Closes #762 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP cache expiry (new setting defaults to 60s; values below 60s are rejected and fallback to 60s).
  * Responses now include Cache-Control headers using the configured expiry to enable client-side caching.

* **Chores**
  * Project version bumped to 1.26.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->