### PR TITLE
:construction_worker: ci: publish container images to GHCR on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,19 +1,15 @@
-name: Release stable image
+name: Publish container images
 
 on:
-  push:
-    branches:
-      - "release/stable/**"
-  pull_request:
-    branches:
-      - "release/stable/**"
-    types: [opened, synchronize]
+  release:
+    types: [published]
 
 env:
-  CARGO_TERM_COLOR: always
+  GHCR_IMAGE: ghcr.io/neon-mmd/websurfx
+  QUAY_IMAGE: quay.io/neon-mmd/websurfx
 
 jobs:
-  release_image:
+  publish:
     strategy:
       fail-fast: false
       matrix:
@@ -23,57 +19,60 @@ jobs:
           - hybrid
           - no-cache
 
-    name: Release ${{ matrix.cache }} image
+    name: Publish ${{ matrix.cache }} image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-      - uses: actions/checkout@v6
-      # Install buildx
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-      # Set buildx cache
-      - name: Cache register
-        uses: actions/cache@v5
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
         with:
-          path: /tmp/.buildx-cache
-          key: buildx-cache
-      # Login to ghcr.io
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:          
-          username: neonmmd
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      # Extract branch info
-      - name: Set info
-        run: |
-          echo "VERSION=$(echo ${GITHUB_REF} | awk -F/ '{print $6}')" >> $GITHUB_ENV
-      # Print info for debug
-      - name: Print Info
-        run: |
-          echo $VERSION
-      # Create buildx multiarch
-      - name: Create buildx multiarch
-        run: docker buildx create --use --name=buildx-multi-arch --driver=docker-container --driver-opt=network=host
-      # Modify cache variable in the dockerfile.
-      - name: Modify Cache variable
-        run: | 
-          sed -i "s/ARG CACHE=[a-z]*/ARG CACHE=${{ matrix.cache }}/g" Dockerfile
-      # Publish image
-      - name: Publish image
-        run: docker buildx build --builder=buildx-multi-arch --platform=linux/amd64,linux/arm64 --build-arg CACHE=${{ matrix.cache }} --push -t neonmmd/websurfx:$VERSION-${{ matrix.cache }} -t neon-mmd/websurfx:${{matrix.cache}} -f Dockerfile .
-      - name: Publish latest
-        if: ${{ matrix.cache }} == 'hybrid'
-        run: docker buildx build --builder=buildx-multi-arch --platform=linux/amd64,linux/arm64 --build-arg CACHE=${{ matrix.cache }} --push -t neon-mmd/websurfx:latest -f Dockerfile .
-      # Upload it to release
-      - name: Test if release already exists
-        id: release-exists
-        continue-on-error: true
-        run: gh release view $BINARY_NAME-$VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create new draft release
-        if: steps.release-exists.outcome == 'failure' && steps.release-exists.conclusion == 'success'
-        run: gh release create -t $VERSION -d $VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Quay
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.QUAY_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-${{ matrix.cache }}
+            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.cache }}
+            type=raw,value=latest,enable=${{ matrix.cache == 'memory' }}
+            type=raw,value=${{ matrix.cache }},enable=true
+
+      - name: Modify cache variant in Dockerfile
+        run: sed -i "s/ARG CACHE=[a-z-]*/ARG CACHE=${{ matrix.cache }}/g" Dockerfile
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.cache }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache }}
+          build-args: CACHE=${{ matrix.cache }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,10 +3,7 @@ name: Publish container images
 on:
   release:
     types: [published]
-
-env:
-  GHCR_IMAGE: ghcr.io/neon-mmd/websurfx
-  QUAY_IMAGE: quay.io/neon-mmd/websurfx
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -42,20 +39,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to Quay
-        uses: docker/login-action@v4
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.GHCR_IMAGE }}
-            ${{ env.QUAY_IMAGE }}
+          images: ghcr.io/${{ github.repository_owner }}/websurfx
           tags: |
             type=semver,pattern={{version}},suffix=-${{ matrix.cache }}
             type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.cache }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Publish container images
+name: Publish stable container images
 
 on:
   release:
@@ -32,6 +32,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: neonmmd
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -43,10 +49,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/websurfx
+          images: |
+            neonmmd/websurfx
+            ghcr.io/${{ github.repository_owner }}/websurfx
           tags: |
             type=semver,pattern={{raw}},suffix=-${{ matrix.cache }}
-            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.cache }}
             type=raw,value=latest,enable=${{ matrix.cache == 'memory' && !github.event.release.prerelease }}
             type=raw,value=${{ matrix.cache }},enable=true
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,9 +50,6 @@ jobs:
             type=raw,value=latest,enable=${{ matrix.cache == 'memory' && !github.event.release.prerelease }}
             type=raw,value=${{ matrix.cache }},enable=true
 
-      - name: Modify cache variant in Dockerfile
-        run: sed -i "s/ARG CACHE=[a-z-]*/ARG CACHE=${{ matrix.cache }}/g" Dockerfile
-
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,9 +45,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/websurfx
           tags: |
-            type=semver,pattern={{version}},suffix=-${{ matrix.cache }}
+            type=semver,pattern={{raw}},suffix=-${{ matrix.cache }}
             type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.cache }}
-            type=raw,value=latest,enable=${{ matrix.cache == 'memory' }}
+            type=raw,value=latest,enable=${{ matrix.cache == 'memory' && !github.event.release.prerelease }}
             type=raw,value=${{ matrix.cache }},enable=true
 
       - name: Modify cache variant in Dockerfile


### PR DESCRIPTION
Adds a GitHub Actions workflow to publish container images to GHCR on stable releases.

## What this does
- Publishes all four cache variants (`memory`, `redis`, `hybrid`, `no-cache`) to `ghcr.io/neon-mmd/websurfx`
- Tags: `v1.x.x-<cache>` (semver with raw prefix), `<cache>` (floating), `latest` (memory only, non-prerelease)
- Multi-arch: `linux/amd64` + `linux/arm64`

## Out of scope
Rolling/nightly builds from the `rolling` branch are tracked separately in #776.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build and deployment infrastructure for improved efficiency and reliability.

**Note:** This release contains no user-visible changes. All modifications are internal improvements to development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->