### PR TITLE
✨ feat(engine): `qwant` for the search engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,13 +8,13 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes 1.11.1",
  "futures-core",
  "futures-sink",
  "memchr",
  "pin-project-lite",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-util",
  "tracing",
 ]
@@ -44,7 +44,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes 1.11.1",
  "derive_more 2.1.1",
  "futures-core",
@@ -79,7 +79,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "brotli",
  "bytes 1.11.1",
  "bytestring",
@@ -96,7 +96,7 @@ dependencies = [
  "percent-encoding 2.3.2",
  "pin-project-lite",
  "smallvec 1.15.1",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-util",
  "tracing",
 ]
@@ -133,7 +133,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "tempfile",
- "tokio 1.51.0",
+ "tokio 1.52.0",
 ]
 
 [[package]]
@@ -170,7 +170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
 dependencies = [
  "futures-core",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-uring",
 ]
 
@@ -187,7 +187,7 @@ dependencies = [
  "futures-util",
  "mio 1.2.0",
  "socket2 0.5.10",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-uring",
  "tracing",
 ]
@@ -406,7 +406,7 @@ dependencies = [
  "compression-codecs",
  "compression-core",
  "pin-project-lite",
- "tokio 1.51.0",
+ "tokio 1.52.0",
 ]
 
 [[package]]
@@ -514,9 +514,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
@@ -609,9 +609,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -769,7 +769,7 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-util",
 ]
 
@@ -1401,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1693,7 +1693,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec 1.15.1",
  "spinning_top",
  "web-time",
@@ -1729,9 +1729,9 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-util",
  "tracing",
 ]
@@ -1788,6 +1788,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1957,22 +1963,21 @@ dependencies = [
  "itoa 1.0.18",
  "pin-project-lite",
  "smallvec 1.15.1",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "want 0.3.1",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
@@ -2009,7 +2014,7 @@ dependencies = [
  "percent-encoding 2.3.2",
  "pin-project-lite",
  "socket2 0.6.3",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tower-service",
  "tracing",
 ]
@@ -2169,12 +2174,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2255,9 +2260,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
@@ -2306,9 +2311,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libflate"
@@ -2347,13 +2352,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84f971730745f4aaac013b6cf4328baf1548efc973c0d95cfd843a3c1ca07af"
 dependencies = [
  "ahash",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "const-str",
  "cssparser 0.33.0",
  "cssparser-color",
  "data-encoding",
  "getrandom 0.2.17",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
@@ -2791,11 +2796,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if 1.0.4",
  "foreign-types",
  "libc",
@@ -2823,9 +2828,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -2849,7 +2854,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cssparser 0.33.0",
  "log",
  "phf 0.11.3",
@@ -3108,9 +3113,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -3251,7 +3256,7 @@ dependencies = [
  "rustls",
  "socket2 0.6.3",
  "thiserror",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tracing",
  "web-time",
 ]
@@ -3265,7 +3270,7 @@ dependencies = [
  "bytes 1.11.1",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -3353,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3492,14 +3497,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3543,7 +3548,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "socket2 0.6.3",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-util",
  "url 2.5.8",
 ]
@@ -3560,7 +3565,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3659,7 +3664,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.7.1",
  "sync_wrapper",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -3733,7 +3738,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3742,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "ring",
@@ -3766,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3843,7 +3848,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3876,7 +3881,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cssparser 0.36.0",
  "derive_more 2.1.1",
  "log",
@@ -4431,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes 1.11.1",
  "libc",
@@ -4525,7 +4530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio 1.51.0",
+ "tokio 1.52.0",
 ]
 
 [[package]]
@@ -4592,7 +4597,7 @@ dependencies = [
  "libc",
  "slab",
  "socket2 0.4.10",
- "tokio 1.51.0",
+ "tokio 1.52.0",
 ]
 
 [[package]]
@@ -4605,7 +4610,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "tokio 1.51.0",
+ "tokio 1.52.0",
 ]
 
 [[package]]
@@ -4627,7 +4632,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tower-layer",
  "tower-service",
 ]
@@ -4639,7 +4644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes 1.11.1",
  "futures-core",
  "futures-util",
@@ -4648,7 +4653,7 @@ dependencies = [
  "http-body-util",
  "iri-string",
  "pin-project-lite",
- "tokio 1.51.0",
+ "tokio 1.52.0",
  "tokio-util",
  "tower",
  "tower-layer",
@@ -4922,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -4935,9 +4940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4945,9 +4950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -4955,9 +4960,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2 1.0.106",
@@ -4968,9 +4973,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4992,7 +4997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5003,17 +5008,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver 1.0.28",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5052,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "websurfx"
-version = "1.26.0"
+version = "1.28.0"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -5094,7 +5099,7 @@ dependencies = [
  "stop-words",
  "tempfile",
  "thesaurus",
- "tokio 1.51.0",
+ "tokio 1.52.0",
 ]
 
 [[package]]
@@ -5348,7 +5353,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5378,8 +5383,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5398,7 +5403,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver 1.0.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websurfx"
-version = "1.26.0"
+version = "1.28.0"
 edition = "2024"
 description = "An open-source alternative to Searx that provides clean, ad-free, and organic results with incredible speed while keeping privacy and security in mind."
 repository = "https://github.com/neon-mmd/websurfx"

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -8,6 +8,7 @@ pub mod brave;
 pub mod duckduckgo;
 pub mod librex;
 pub mod mojeek;
+pub mod qwant;
 mod search_result_parser;
 pub mod searx;
 pub mod sepiasearch;

--- a/src/engines/qwant.rs
+++ b/src/engines/qwant.rs
@@ -144,7 +144,10 @@ impl SearchEngine for Qwant {
     ) -> Result<Vec<(String, SearchResult)>, EngineError> {
         // Qwant uses 0-based offset with 10 results per page.
         let count: u32 = 10;
-        let offset = page * count;
+        let offset = page.checked_mul(count).ok_or_else(|| {
+            Report::new(EngineError::UnexpectedError)
+                .attach("Qwant pagination overflow while computing offset")
+        })?;
 
         // Build the API URL with properly encoded query parameters.
         let query_encoded: String = form_urlencoded::byte_serialize(query.as_bytes()).collect();

--- a/src/engines/qwant.rs
+++ b/src/engines/qwant.rs
@@ -1,0 +1,285 @@
+//! The `qwant` module handles the fetching of results from the Qwant search engine
+//! by querying the upstream Qwant JSON API with the user provided query and with a page
+//! number if provided.
+
+use crate::models::aggregation::SearchResult;
+use crate::models::engine::{EngineError, SearchEngine};
+use error_stack::{Report, Result, ResultExt};
+use reqwest::{Client, header::HeaderMap};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// A new Qwant engine type defined in-order to implement the `SearchEngine` trait.
+pub struct Qwant;
+
+/// A single web page search result from the Qwant API.
+#[derive(Deserialize)]
+struct QwantSearchResult {
+    /// Title of the result.
+    title: String,
+    /// URL of the result.
+    url: String,
+    /// Description snippet of the result.
+    desc: String,
+}
+
+/// A categorized result item from the Qwant API.
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum QwantItem {
+    /// Results containing web pages relevant to the query.
+    #[serde(rename = "web")]
+    Web {
+        /// List of web page search results.
+        items: Vec<QwantSearchResult>,
+    },
+    /// Other item types (related searches, ads, etc.) which are not relevant.
+    #[serde(other)]
+    Other,
+}
+
+/// The mainline container holding categorized result items.
+#[derive(Deserialize)]
+struct QwantMainline {
+    /// Results displayed in the main section.
+    mainline: Vec<QwantItem>,
+}
+
+/// The top-level result object from a successful Qwant API response.
+#[derive(Deserialize)]
+struct QwantResult {
+    /// Categorized result items.
+    items: QwantMainline,
+}
+
+/// The full Qwant API response, tagged by status.
+#[derive(Deserialize)]
+#[serde(tag = "status", content = "data", rename_all = "lowercase")]
+enum QwantApiResponse {
+    /// A successful response containing search results.
+    Success {
+        /// The actual search results.
+        result: QwantResult,
+    },
+    /// An error response from the Qwant API.
+    Error {
+        /// Machine-readable error code.
+        #[serde(rename = "errorCode")]
+        error_code: i32,
+        /// Human-readable error messages.
+        #[serde(default)]
+        message: Vec<String>,
+    },
+}
+
+impl Qwant {
+    /// Creates a new Qwant engine instance.
+    ///
+    /// # Returns
+    ///
+    /// It returns a `Qwant` struct on success.
+    pub fn new() -> Result<Qwant, EngineError> {
+        Ok(Self)
+    }
+
+    /// Parses the raw JSON response body into a list of search results.
+    ///
+    /// # Arguments
+    ///
+    /// * `json` - A byte slice of the raw JSON response body.
+    ///
+    /// # Error
+    ///
+    /// It returns an `EngineError` if the API response indicates an error or if the
+    /// response cannot be parsed.
+    fn parse_json_response(json: &[u8]) -> Result<Vec<(String, SearchResult)>, EngineError> {
+        let response: QwantApiResponse =
+            serde_json::from_slice(json).change_context(EngineError::UnexpectedError)?;
+
+        let result = match response {
+            QwantApiResponse::Success { result } => result,
+            QwantApiResponse::Error {
+                error_code,
+                message,
+            } => {
+                let msg = message.first().map(|s| s.as_str()).unwrap_or("unknown");
+                return Err(Report::new(EngineError::UnexpectedError)
+                    .attach(format!("Qwant API error {error_code}: {msg}")));
+            }
+        };
+
+        let results: Vec<_> = result
+            .items
+            .mainline
+            .into_iter()
+            .filter_map(|item| match item {
+                QwantItem::Web { items } => Some(items),
+                _ => None,
+            })
+            .flatten()
+            .map(|item| {
+                let search_result = SearchResult::new(
+                    item.title.trim(),
+                    item.url.as_str(),
+                    item.desc.trim(),
+                    &["qwant"],
+                );
+                (item.url, search_result)
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[async_trait::async_trait]
+impl SearchEngine for Qwant {
+    async fn results(
+        &self,
+        query: &str,
+        page: u32,
+        user_agent: &str,
+        client: &Client,
+        safe_search: u8,
+    ) -> Result<Vec<(String, SearchResult)>, EngineError> {
+        // Qwant uses 0-based offset with 10 results per page.
+        let count: u32 = 10;
+        let offset = page * count;
+
+        // Build the API URL with properly encoded query parameters.
+        let query_encoded: String = form_urlencoded::byte_serialize(query.as_bytes()).collect();
+        let url = format!(
+            "https://api.qwant.com/v3/search/web?q={query_encoded}&count={count}&locale=en_US&offset={offset}&safesearch={safe_search}&device=desktop&tgb=2&displayed=true"
+        );
+
+        let header_map = HeaderMap::try_from(&HashMap::from([
+            ("User-Agent".to_string(), user_agent.to_string()),
+            ("Referer".to_string(), "https://www.qwant.com/".to_string()),
+        ]))
+        .change_context(EngineError::UnexpectedError)?;
+
+        let json_bytes =
+            Qwant::fetch_json_as_bytes_from_upstream(self, &url, header_map, client).await?;
+
+        let results = Self::parse_json_response(&json_bytes)?;
+
+        if results.is_empty() {
+            return Err(Report::new(EngineError::EmptyResultSet));
+        }
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_json_response_success() {
+        let json = br#"{
+            "status": "success",
+            "data": {
+                "result": {
+                    "items": {
+                        "mainline": [
+                            {
+                                "type": "web",
+                                "items": [
+                                    {
+                                        "title": "Rust Programming Language",
+                                        "url": "https://www.rust-lang.org/",
+                                        "desc": "A language empowering everyone to build reliable software."
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }"#;
+
+        let results = Qwant::parse_json_response(json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1.title, "Rust Programming Language");
+        assert_eq!(results[0].1.url, "https://www.rust-lang.org/");
+        assert_eq!(
+            results[0].1.description,
+            "A language empowering everyone to build reliable software."
+        );
+        assert_eq!(results[0].1.engine, vec!["qwant"]);
+    }
+
+    #[test]
+    fn test_parse_json_response_filters_non_web_items() {
+        let json = br#"{
+            "status": "success",
+            "data": {
+                "result": {
+                    "items": {
+                        "mainline": [
+                            {
+                                "type": "web",
+                                "items": [
+                                    {
+                                        "title": "Result 1",
+                                        "url": "https://example.com/1",
+                                        "desc": "Description 1"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "related_searches",
+                                "items": []
+                            },
+                            {
+                                "type": "web",
+                                "items": [
+                                    {
+                                        "title": "Result 2",
+                                        "url": "https://example.com/2",
+                                        "desc": "Description 2"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }"#;
+
+        let results = Qwant::parse_json_response(json).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_json_response_error() {
+        let json = br#"{
+            "status": "error",
+            "data": {
+                "errorCode": 27,
+                "message": ["Captcha required"]
+            }
+        }"#;
+
+        let result = Qwant::parse_json_response(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_json_response_empty_results() {
+        let json = br#"{
+            "status": "success",
+            "data": {
+                "result": {
+                    "items": {
+                        "mainline": []
+                    }
+                }
+            }
+        }"#;
+
+        let results = Qwant::parse_json_response(json).unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/src/models/engine.rs
+++ b/src/models/engine.rs
@@ -214,6 +214,10 @@ impl EngineHandler {
                     let engine = crate::engines::yahoo::Yahoo::new()?;
                     ("yahoo", Box::new(engine))
                 }
+                "qwant" => {
+                    let engine = crate::engines::qwant::Qwant::new()?;
+                    ("qwant", Box::new(engine))
+                }
                 "sepiasearch" => {
                     let engine = crate::engines::sepiasearch::SepiaSearch::new()?;
                     ("sepiasearch", Box::new(engine))

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -78,6 +78,7 @@ upstream_search_engines = {
 	LibreX = false,
 	Mojeek = false,
 	Bing = false,
+	Qwant = false,
 	Wikipedia = true,
 	Yahoo = false,
 	SepiaSearch = false,


### PR DESCRIPTION
## What does this PR do?

Adds **Qwant** as a new upstream search engine, querying the Qwant v3 JSON API (`api.qwant.com/v3/search/web`).

**Changes:**
- New engine file `src/engines/qwant.rs` implementing the `SearchEngine` trait
- Uses `fetch_json_as_bytes_from_upstream` for HTTP fetching (consistent with SepiaSearch)
- Parses JSON response with serde, filtering for web results only (ignoring ads, related searches, etc.)
- Surfaces API errors (including captcha / error code 27) with context rather than silently masking
- Pagination via `offset` parameter, 10 results per page
- Safe search mapped to Qwant's `safesearch` query parameter
- Unit tests for success response, non-web item filtering, error response, and empty results
- Registered in `mod.rs`, the engine match statement in `engine.rs`, and `config.lua`

## Why is this change important?

Qwant is a privacy-focused search engine that provides an alternative to Google/Bing-based results. Adding it gives websurfx users another upstream option that respects user privacy.

## How to test this PR locally?

1. Enable Qwant in `websurfx/config.lua`:
   ```lua
   Qwant = true,
   ```
2. Build and run:
   ```shell
   cargo run
   ```
3. Search for any query with Qwant enabled. Results should appear from Qwant.
4. Run unit tests:
   ```shell
   cargo test --lib engines::qwant
   ```

## Author's checklist

- [x] Follows existing engine patterns (struct + `SearchEngine` trait impl + constructor)
- [x] All struct fields have doc comments
- [x] Uses `fetch_json_as_bytes_from_upstream` for HTTP fetching
- [x] Query parameter is properly URL-encoded via `form_urlencoded`
- [x] API errors are detected and surfaced with context
- [x] No new dependencies required (`form_urlencoded` already present from SepiaSearch)
- [x] Unit tests for normal response, filtering, error, and empty results
- [x] Bump the app to `v1.28.0` 

## Related issues

Takes over #605 #783 (original work by @nrabulinski, and Franz Kafka). Closes #317.

## Credit

Based on initial implementation by @nrabulinski in #605 and Franz Kafka in #783 — the serde response models and API structure were ported from their work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Qwant as a new upstream search engine option with full result parsing, filtering, and robust error/empty-result handling. Disabled by default in config.

* **Tests**
  * Added unit tests covering successful parsing, filtering non-web items, API error handling, and empty-result behavior.

* **Chores**
  * Package version bumped to 1.28.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->