### PR TITLE
Add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   <a href=""
     ><img
       alt="Maintenance"
-      src="https://img.shields.io/maintenance/yes/2024?style=flat-square"
+      src="https://img.shields.io/maintenance/yes/2026?style=flat-square"
     />
   </a>
   <a href="https://www.codefactor.io/repository/github/neon-mmd/websurfx">
@@ -118,10 +118,21 @@
 - ⬆️  Organic Search results (with ranking algorithm builtin to rerank the search results according to user's search query.).
 - 🔒 Different compression and encryption levels focusing on speed and privacy.
 - 🧪 Experimental IO-uring feature for Linux operating systems focused on performance of the engine.
+- 🧅 Custom proxy and Tor support for fetching search results from the upstream search engines.
 - 🔐 Fast, private, and secure
 - 🆓 100% free and open source
 - 💨 Ad-free and clean results
 - 🌟 and lots more...
+
+**[⬆️ Back to Top](#--)**
+
+# Deployment 🚀
+
+## Deploy on RepoCloud
+
+Deploy Websurfx instantly with one click on RepoCloud:
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Websurfx/)
 
 **[⬆️ Back to Top](#--)**
 

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -6,7 +6,7 @@ threads = 10 -- the amount of threads that the app will use to run (the value sh
 -- ### Server ###
 port = "8080" -- port on which server should be launched
 binding_ip = "127.0.0.1" --ip address on the which server should be launched.
-production_use = true -- whether to use production mode or not (in other words this option should be used if it is to be used to host it on the server to provide a service to a large number of users (more than one))
+production_use = false -- whether to use production mode or not (in other words this option should be used if it is to be used to host it on the server to provide a service to a large number of users (more than one))
 -- if production_use is set to true
 -- There will be a random delay before sending the request to the search engines, this is to prevent DDoSing the upstream search engines from a large number of simultaneous requests.
 request_timeout = 30 -- timeout for the search requests sent to the upstream search engines to be fetched (value in seconds).
@@ -61,7 +61,7 @@ theme = "simple" -- the theme name which should be used for the website
 animation = "simple-frosted-glow" -- the animation name which should be used with the theme or `nil` if you don't want any animations.
 
 -- ### Caching ###
-redis_url = "redis://default:722302d75f726e23f0e9@websurfx_redis:6379" -- redis connection url address on which the client should connect on.
+redis_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
 cache_expiry_time = 600 -- This option takes the expiry time of the search results (value in seconds and the value should be greater than or equal to 60 seconds).
 -- ### Search Engines ###
 upstream_search_engines = {

--- a/websurfx/config.lua
+++ b/websurfx/config.lua
@@ -6,7 +6,7 @@ threads = 10 -- the amount of threads that the app will use to run (the value sh
 -- ### Server ###
 port = "8080" -- port on which server should be launched
 binding_ip = "127.0.0.1" --ip address on the which server should be launched.
-production_use = false -- whether to use production mode or not (in other words this option should be used if it is to be used to host it on the server to provide a service to a large number of users (more than one))
+production_use = true -- whether to use production mode or not (in other words this option should be used if it is to be used to host it on the server to provide a service to a large number of users (more than one))
 -- if production_use is set to true
 -- There will be a random delay before sending the request to the search engines, this is to prevent DDoSing the upstream search engines from a large number of simultaneous requests.
 request_timeout = 30 -- timeout for the search requests sent to the upstream search engines to be fetched (value in seconds).
@@ -61,7 +61,7 @@ theme = "simple" -- the theme name which should be used for the website
 animation = "simple-frosted-glow" -- the animation name which should be used with the theme or `nil` if you don't want any animations.
 
 -- ### Caching ###
-redis_url = "redis://127.0.0.1:8082" -- redis connection url address on which the client should connect on.
+redis_url = "redis://default:722302d75f726e23f0e9@websurfx_redis:6379" -- redis connection url address on which the client should connect on.
 cache_expiry_time = 600 -- This option takes the expiry time of the search results (value in seconds and the value should be greater than or equal to 60 seconds).
 -- ### Search Engines ###
 upstream_search_engines = {


### PR DESCRIPTION
This PR adds a one-click deployment section with a RepoCloud deploy button, making it easy for users to deploy Websurfx to managed cloud infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the maintenance badge to reflect 2026.
  * Documented custom proxy and Tor support.
  * Added one-click RepoCloud deployment instructions and badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->